### PR TITLE
Add support for section pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+
+{{ partial "head.html" . }}
+
+<body>
+    {{ partial "header.html" . }}
+
+    <main class="content-wrapper">
+        <article class="content-container">
+            <section>
+                <h2>{{ .Title }}</h2>
+                <ul>
+                    {{ range where .Site.RegularPages "Section" .Section }}
+                    <li>
+                        <a href="{{ .Permalink }}">{{ .Title }}</a>
+                    </li>
+                    {{ end }}
+                </ul>
+            </section>
+
+        {{ partial "footer.html" . }}
+        </article>
+    </main>
+</body>
+
+</html>


### PR DESCRIPTION
This change adds support for section pages like https://example.com/posts/

The title is the title of the section (e.g. 'Posts') and the list is the pages in the section.

You can have as many sections as you like:

```
content/posts/hello-world.md
content/essays/why-the-world-is-doomed.md
content/notes/how-to-email-me.md
```

For a better section title put an `_index.md` in the section directory and set the title there.