### PR TITLE
Add support for taxonomy pages

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+
+{{ partial "head.html" . }}
+
+<body>
+    {{ partial "header.html" . }}
+
+    <main class="content-wrapper">
+        <article class="content-container">
+            <section>
+                <h2>{{ .Data.Singular }}: {{ .Name }}</h2>
+                <ul>
+                    {{ range .RegularPages }}
+                    <li>
+                        <a href="{{ .Permalink }}">{{ .Title }}</a>
+                    </li>
+                    {{ end }}
+                </ul>
+            </section>
+
+        {{ partial "footer.html" . }}
+        </article>
+    </main>
+</body>
+
+</html>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+
+{{ partial "head.html" . }}
+
+<body>
+    {{ partial "header.html" . }}
+
+    <main class="content-wrapper">
+        <article class="content-container">
+            <section>
+                <h2>{{ .Title }}</h2>
+                <ul>
+                    {{ range .Data.Terms.Alphabetical }}
+                    <li>
+                        <a href="{{ .Page.Permalink }}">{{ .Page.Name }}</a> ({{ .Count }})
+                    </li>
+                    {{ end }}
+                </ul>
+            </section>
+
+        {{ partial "footer.html" . }}
+        </article>
+    </main>
+</body>
+
+</html>


### PR DESCRIPTION
This change adds support for taxonomy pages like https://example.com/tags/, https://example.com/tags/my-tag-name, https://example.com/categories/, and https://example.com/categories/my-category-name

`terms.html` shows all the tags/categories and `taxonomy.html` shows all the content associated with a given tag/category.