### PR TITLE
Show multiple sections on home page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,16 +16,18 @@
             </section>
             {{- end }}
 
+            {{ range sort (where .Site.Sections "Weight" "ne" -1) "Weight" }}
             <section>
-                <h2>Posts</h2>
+                <h2>{{ .Title }}</h2>
                 <ul>
-                    {{ range .Site.RegularPages }}
+                    {{ range where .Site.RegularPages "Section" .Section }}
                     <li>
                         <a href="{{ .Permalink }}">{{ .Title }}</a>
                     </li>
                     {{ end }}
                 </ul>
             </section>
+            {{ end }}
 
         {{ partial "footer.html" . }}
         </article>


### PR DESCRIPTION
This change adds support for multiple sections on the home page.

Instead of just 'Posts', now content is listed under its own section title.

The sections are sorted by weight (lowest to highest) and any section with a weight of -1 is filtered out. To filter out the content in `content/notes/`, for example, create `content/notes/_index.md` and set weight to -1 there.

```
+++
title = 'Notes'
weight = -1
+++
```

A good side effect of this change is that meta-pages like `content/about.md` (pretty standard) are no longer listed under 'Posts'.