### PR TITLE
Make it work without JS

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,8 @@
 <head>
+    <script>
+      document.documentElement.style.setProperty("--preload-visibility", "hidden");
+    </script>
+
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ .Title }}</title>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -48,7 +48,7 @@ body,
 }
 
 html {
-  visibility: hidden;
+  visibility: var(--preload-visibility);
 }
 
 html.js-loaded {


### PR DESCRIPTION
This theme shows a blank page if JS is disabled.

This patch fixes the issue by displaying the content by default and doing the transition thing only if JS is available.