### PR TITLE
Add canonical URL

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,6 +3,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ .Title }}</title>
     
+    {{ if not (strings.HasSuffix .RelPermalink "/404.html") }}
+    <link rel="canonical" href="{{ .Permalink }}" />
+    {{ end }}
+
     {{- partial "opengraph.html" . -}}
 
     <meta name="author" content="{{ .Site.Params.author }}" />


### PR DESCRIPTION
This change adds a canonical URL in the `<head>` block.

The canonical URL of a page not found must be the URL that was requested, we don't have this at build time in `404.html`, so we don't set it at all.