### PR TITLE
Remove hyphen from copyright footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer>
     <div class="footer-content">
-        <p>&copy; {{ now.Year }} - {{ .Site.Title }}</p>
+        <p>&copy; {{ now.Year }} {{ .Site.Title }}</p>
     </div>
 </footer>


### PR DESCRIPTION
The convention for the copyright footer is to put a space between the year and the owner. i.e. '&copy; 2025 GitHub, Inc.' rather than '&copy; 2025 - GitHub, Inc.'

This change removes the hyphen.