### PR TITLE
Unescape smart punctuation in SVG

### DIFF
--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -18,6 +18,9 @@
   {{ $isDefault = true }}
 {{ end }}
 
+{{ $title = partial "unescape_smart.html" $title }}
+{{ $description = partial "unescape_smart.html" $description }}
+
 {{ $svg := printf `
     <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
         <style>

--- a/layouts/partials/unescape_smart.html
+++ b/layouts/partials/unescape_smart.html
@@ -1,8 +1,8 @@
-{{- $s := . -}}
-{{- $s = replace $s "&rsquo;" "’" -}}
-{{- $s = replace $s "&lsquo;" "‘" -}}
-{{- $s = replace $s "&rdquo;" "”" -}}
-{{- $s = replace $s "&ldquo;" "“" -}}
-{{- $s = replace $s "&ndash;" "–" -}}
-{{- $s = replace $s "&mdash;" "—" -}}
-{{- return $s -}}
+{{- $text := . -}}
+{{- $text = replace $text "&rsquo;" "’" -}}
+{{- $text = replace $text "&lsquo;" "‘" -}}
+{{- $text = replace $text "&rdquo;" "”" -}}
+{{- $text = replace $text "&ldquo;" "“" -}}
+{{- $text = replace $text "&ndash;" "–" -}}
+{{- $text = replace $text "&mdash;" "—" -}}
+{{- return $text -}}

--- a/layouts/partials/unescape_smart.html
+++ b/layouts/partials/unescape_smart.html
@@ -1,0 +1,8 @@
+{{- $s := . -}}
+{{- $s = replace $s "&rsquo;" "’" -}}
+{{- $s = replace $s "&lsquo;" "‘" -}}
+{{- $s = replace $s "&rdquo;" "”" -}}
+{{- $s = replace $s "&ldquo;" "“" -}}
+{{- $s = replace $s "&ndash;" "–" -}}
+{{- $s = replace $s "&mdash;" "—" -}}
+{{- return $s -}}


### PR DESCRIPTION
If the page description has an apostrophe (e.g. "What's happening?"), Hugo converts it into a smart apostrophe (Unicode: 8217), but it encodes this as HTML entity `&rsquo;`. Since this is not valid in SVG, we get an error.

This patch _unescapes_ smart punctuation (only) to convert it back to the original Unicode characters. This is valid SVG.