### PR TITLE
Set background color on <svg /> element

### DIFF
--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -21,6 +21,9 @@
 {{ $svg := printf `
     <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
         <style>
+            svg {
+              background-color: #f0efea;
+            }
             @font-face {
               font-family: 'Newsreader';
               src: url('/fonts/Newsreader.woff2') format('woff2');


### PR DESCRIPTION
The generated SVG image has a white background and then a smaller off-white rectangle on top of it. This looks incomplete.

This patch adds the same background to the `<svg />` element as well so that the entire image has the same background color.