### PR TITLE
Show page description in meta tag

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,7 +12,7 @@
     {{ end }}
 
     <meta name="author" content="{{ .Site.Params.author }}" />
-    <meta name="description" content="{{ .Site.Params.description }}" />
+    <meta name="description" content="{{ .Description | default .Summary | default .Site.Params.description | plainify | replaceRE "\\s+" " " | truncate 150 }}" />
 
     <link rel="preload" href="{{ "fonts/Newsreader.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="{{ "fonts/Newsreader-italic.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />


### PR DESCRIPTION
This patch prioritizes the page's own description on individual pages. If the page has no description or summary, it uses the site's description.

Also, HTML tags are stripped via `plainify`, whitespace is collapsed via `replaceRE`, and the result is truncated to 150 characters.