### PR TITLE
Plainify og:description

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{{ .Title }}</title>
+    <title>{{ .Title | default .Site.Title }}</title>
 
     {{ if strings.HasSuffix .RelPermalink "/404.html" }}
     <meta name="robots" content="noindex, nofollow" />
@@ -12,7 +12,7 @@
     {{ end }}
 
     <meta name="author" content="{{ .Site.Params.author }}" />
-    <meta name="description" content="{{ .Description | default .Summary | default .Site.Params.description | plainify | replaceRE "\\s+" " " | truncate 150 }}" />
+    <meta name="description" content="{{ .Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " ") | default .Site.Params.description | truncate 150 }}" />
 
     <link rel="preload" href="{{ "fonts/Newsreader.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="{{ "fonts/Newsreader-italic.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -1,5 +1,5 @@
-{{ $title := .Params.ogTitle | default .Title }}
-{{ $description := .Params.ogDescription | default .Description | default site.Params.homeInfoParams.Description | default .Summary | truncate 150 }}
+{{ $title := .Params.ogTitle | default .Title | default site.Title }}
+{{ $description := .Params.ogDescription | default .Description | default site.Params.homeInfoParams.Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " ") | default site.Params.description | truncate 150 }}
 
 <!-- Handle base URL for local dev vs production -->
 {{ $baseURL := .Site.BaseURL | strings.TrimSuffix "/" }}
@@ -17,9 +17,6 @@
   {{ $uniqueName = "default.png" }}
   {{ $isDefault = true }}
 {{ end }}
-
-{{ $title = partial "unescape_smart.html" $title }}
-{{ $description = partial "unescape_smart.html" $description }}
 
 {{ $svg := printf `
     <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
@@ -46,7 +43,7 @@
             </div>
         </foreignObject>
     </svg>
-    ` $title $description | safeHTML }}
+    ` ($title | htmlEscape) $description | safeHTML }}
 
 {{ $generatedSVG := resources.FromString $uniqueName $svg | resources.ExecuteAsTemplate $uniqueName . }}
 

--- a/layouts/partials/unescape_smart.html
+++ b/layouts/partials/unescape_smart.html
@@ -1,8 +1,0 @@
-{{- $text := . -}}
-{{- $text = replace $text "&rsquo;" "’" -}}
-{{- $text = replace $text "&lsquo;" "‘" -}}
-{{- $text = replace $text "&rdquo;" "”" -}}
-{{- $text = replace $text "&ldquo;" "“" -}}
-{{- $text = replace $text "&ndash;" "–" -}}
-{{- $text = replace $text "&mdash;" "—" -}}
-{{- return $text -}}


### PR DESCRIPTION
Now we plainify the value of `og:description` as well.

Notes:

1.  We run `plainify | htmlUnescape | replaceRE "\\s+" " "` on `.Summary` only.
2. `replaceRE` ends up re-escaping things like `&` to `&amp;`, that's why we need to use `htmlUnescape`.
3. Since we're using `htmlUnescape` now, we use it _before_ `replaceRE` and get rid of the `unescape_smart.html` partial altogether.
4. `safeHTML` turns off escaping. `$description` is already escaped (Hugo magic!), but `$title` is not. We run `htmlEscape` on `$title` to make sure characters like `>` in the title are encoded.
5. If there's no page title, we fall back to the site title.