### PR TITLE
Use ISO 8601 in datetime attribute

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
 
     {{ if .Section }}
     <p class="author-date">
-        <time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time>
+        {{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}
     </p>
     {{ end }}
 


### PR DESCRIPTION
The value of `.Date` is not in a format that's [valid for HTML](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-global-date-and-time-string).

The reason for using `printf` is to avoid encoding `+` as `&#43;`, as this would also make the value invalid.