### PR TITLE
Replace homeInfoParams with _intro.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,18 @@ theme = "dario"
 [params]
   author = "Your Name" # the author of the site
   description = "A description of your site" # a description of your site that will be used in the meta tags
+```
 
-  [params.homeInfoParams]
-    Title = "Home Page Text" # the text to display on the "/" homepage
-    Content = "This is a minimal web log inspired by Dario Amodei's personal [website](https://darioamodei.com/). Add some more text here that will be displayed on your homepage (you can use markdown)."
-    Description = "A minimal web log." # The description of the home page that will be used in the open graph meta tags
+To add intro text to your home page, create a file at `content/_intro.md` with contents similar to the following:
+
+```toml
++++
+headless = true
+title = "Home Page Text" # the text to display on the "/" homepage
+description = "A minimal web log." # The description of the home page that will be used in the open graph meta tags
++++
+
+This is a minimal web log inspired by Dario Amodei's personal [website](https://darioamodei.com/). Add some more text here that will be displayed on your homepage (you can use markdown).
 ```
 
 ### Optional Settings

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,9 +1,8 @@
 {{ define "main" }}
-    {{- with site.Params.homeInfoParams }}
+    {{- with .Site.GetPage "_intro.md" }}
     <section>
-    <h1 class="smaller">{{ .Title | markdownify }}</h1>
-    <p>{{ .Content | markdownify }}</p>
-    <p>{{ .SubContent | markdownify }}</p>
+    <h1 class="smaller">{{ .Params.title }}</h1>
+    {{ .Content }}
     </section>
     {{- end }}
 


### PR DESCRIPTION
`homeInfoParams.Content` is supposed to be Markdown, but it's painful to edit Markdown in a TOML file as a property value.

This patch introduces a new mechanism: `content/_intro.md`. If the file exists, its contents are rendered as the intro text on the home page. The front matter's `title` and `description` properties replace `homeInfoParams.Title` and `homeInfoParams.Description` respectively. The body of the file (Markdown) is used in place of `homeInfoParams.Content`.

`headless = true` should be set in `_intro.md` to prevent the generation of `/_intro/index.html` and its inclusion in `sitemap.xml` and such.