### PR TITLE
Use _index.md instead of _intro.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ To add intro text to your home page, create a file at `content/_index.md` with c
 
 ```yaml
 ---
-[params.homeInfo]
-title: "Home Page Text" # the text to display on the "/" homepage
+subtitle: "Home Page Subtitle" # the subtitle to display on the "/" homepage
 description: "A minimal web log." # The description of the home page that will be used in the open graph meta tags
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ theme = "dario"
   description = "A description of your site" # a description of your site that will be used in the meta tags
 ```
 
-To add intro text to your home page, create a file at `content/_intro.md` with contents similar to the following:
+To add intro text to your home page, create a file at `content/_index.md` with contents similar to the following:
 
-```toml
-+++
-headless = true
-title = "Home Page Text" # the text to display on the "/" homepage
-description = "A minimal web log." # The description of the home page that will be used in the open graph meta tags
-+++
+```yaml
+---
+[params.homeInfo]
+title: "Home Page Text" # the text to display on the "/" homepage
+description: "A minimal web log." # The description of the home page that will be used in the open graph meta tags
+---
 
 This is a minimal web log inspired by Dario Amodei's personal [website](https://darioamodei.com/). Add some more text here that will be displayed on your homepage (you can use markdown).
 ```

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,9 +1,12 @@
 {{ define "main" }}
     {{- with .Site.GetPage "_index.md" }}
-    <section>
-    <h1 class="smaller">{{ cond .Params.homeInfo .Params.homeInfo.title "" }}</h1>
-    {{ .Content }}
-    </section>
+        {{- $subtitle := .Params.subtitle }}
+        {{- with .Content }}
+        <section>
+        <h1 class="smaller">{{ $subtitle }}</h1>
+        {{ . }}
+        </section>
+        {{- end }}
     {{- end }}
 
     {{ range sort (where .Site.Sections "Weight" "ne" -1) "Weight" }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
-    {{- with .Site.GetPage "_intro.md" }}
+    {{- with .Site.GetPage "_index.md" }}
     <section>
-    <h1 class="smaller">{{ .Params.title }}</h1>
+    <h1 class="smaller">{{ cond .Params.homeInfo .Params.homeInfo.title "" }}</h1>
     {{ .Content }}
     </section>
     {{- end }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -1,5 +1,13 @@
 {{ $title := .Params.ogTitle | default .Title | default site.Title }}
-{{ $description := .Params.ogDescription | default .Description | default site.Params.homeInfoParams.Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " ") | default site.Params.description | truncate 150 }}
+
+{{ $homeInfoDescription := "" }}
+{{ with site.GetPage "_index.md" }}
+  {{ with .Params.homeInfo }}
+    {{ $homeInfoDescription = .description }}
+  {{ end }}
+{{ end }}
+
+{{ $description := .Params.ogDescription | default .Description | default $homeInfoDescription | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " ") | default site.Params.description | truncate 150 }}
 
 <!-- Handle base URL for local dev vs production -->
 {{ $baseURL := .Site.BaseURL | strings.TrimSuffix "/" }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -1,13 +1,6 @@
 {{ $title := .Params.ogTitle | default .Title | default site.Title }}
 
-{{ $homeInfoDescription := "" }}
-{{ with site.GetPage "_index.md" }}
-  {{ with .Params.homeInfo }}
-    {{ $homeInfoDescription = .description }}
-  {{ end }}
-{{ end }}
-
-{{ $description := .Params.ogDescription | default .Description | default $homeInfoDescription | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " ") | default site.Params.description | truncate 150 }}
+{{ $description := .Params.ogDescription | default .Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " ") | default site.Params.description | truncate 150 }}
 
 <!-- Handle base URL for local dev vs production -->
 {{ $baseURL := .Site.BaseURL | strings.TrimSuffix "/" }}


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/GrantBirki/dario/pull/36#issuecomment-3090082478

It turns out we can just use `content/_index.md` instead. ~~The parameters are specified under `[params.homeInfo]` to avoid overwriting global `title` and `description`.~~

https://github.com/GrantBirki/dario/pull/37 and https://github.com/GrantBirki/dario/pull/38 are withdrawn now and the changes are included here instead.