### PR TITLE
Use mainSections parameter for filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ By default, the theme shows a toggle for switching between light and dark modes.
   useSystemColorScheme = true
 ```
 
+The home page shows the top-level section with the most pages by default. To override this, set `mainSections` to select specific sections:
+
+```toml
+mainSections = ['posts', 'essays', 'notes']
+```
+
 ## Blog Posts
 
 Creating a blog post follows the same general process as most Hugo blogging themes.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
     </section>
     {{- end }}
 
-    {{ range sort (where .Site.Sections "Weight" "ne" -1) "Weight" }}
+    {{ range sort (where .Site.Sections "Section" "in" .Site.MainSections) "Weight" }}
     <section>
     <h2>{{ .Title }}</h2>
     <ul>


### PR DESCRIPTION
https://gohugo.io/methods/site/mainsections/

By default, the top-level section with the most pages is the main section. To change this, set `mainSections` in `hugo.toml`:

```toml
mainSections = ['posts', 'essays']
```

This is a more Hugo way of filtering home page sections rather than setting a section's `weight` to `-1`.