### PR TITLE
Use language code in templates

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{- .Site.Language.LanguageCode -}}">
 
 {{ partial "head.html" . }}
 

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -68,6 +68,7 @@
 <meta property="og:image:height" content="630" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ $baseURL }}{{ .RelPermalink }}" />
+<meta property="og:locale" content="{{- site.Language.LanguageCode -}}" />
 
 <!-- Twitter Cards -->
 <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
This uses the value of [`languageCode`](https://gohugo.io/configuration/all/#languagecode) in the templates.

If no `languageCode` is set in `hugo.toml`, the default is `en`.

Note that this doesn't do any internationalization, it merely reflects what the user has set in their site configuration.