### PR TITLE
Allow 404 page customization

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,6 +1,11 @@
 {{ define "main" }}
     <section>
+        {{- with .Site.GetPage "_404.md" }}
+        <h1 class="smaller">{{ .Params.subtitle }}</h1>
+        {{ .Content }}
+        {{- else }}
         <h1 class="smaller">404</h1>
-        <p>Not found.</p>
+        <p>Page not found.</p>
+        {{- end }}
     </section>
 {{ end }}


### PR DESCRIPTION
This allows for the customization of the 404 page, mainly for localization purposes, by creating `content/_404.md` like so:

```toml
+++
subtitle = "४०४"

[build]
  render = "never"
  list = "never"
+++

पृष्ठ नहीं मिला।
```

This would make sense if your site is in Hindi and your `languageCode` is set to `hi-IN`.