### PR TITLE
Allow custom copyright notice

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,9 @@
 <footer>
     <div class="footer-content">
+        {{- with .Site.Copyright }}
+        <p>{{ . }}</p>
+        {{- else }}
         <p>&copy; {{ now.Year }} {{ .Site.Title }}</p>
+        {{- end }}
     </div>
 </footer>


### PR DESCRIPTION
This change enables the site to have a custom copyright notice via `hugo.toml`:

```toml
copyright = 'Copyright © 2021–2025 John Doe. All rights reserved.'
```

The copyright notice is also used in the default RSS template.