### PR TITLE
Allow custom CSS

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,6 +18,9 @@
     <link rel="preload" href="{{ "fonts/Newsreader-italic.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />
 
     <link rel="stylesheet" href="{{ "css/styles.css" | relURL }}" />
+    {{- with resources.Get "css/custom.css" }}
+    <link rel="stylesheet" href="{{ .RelPermalink }}" />
+    {{- end }}
 
     <link rel="icon" type="image/x-icon" href="{{ "favicon.ico" | relURL }}" />
     <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | relURL }}" />

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -17,6 +17,7 @@
 :root {
   --radius: 8px;
   --highlight-color: rgba(137, 137, 222, 0.3);
+  --font-family-base: "Newsreader";
   --font-size-base: 20px;
   --content-max-width: 620px;
   --content-padding: 0 20px;
@@ -31,7 +32,7 @@ body,
 header h1 a {
   display: block;
   width: 140px;
-  font-family: Newsreader, serif;
+  font-family: var(--font-family-base), serif;
 }
 
 /* Dark Mode Variables */
@@ -144,7 +145,7 @@ body {
 }
 
 body {
-  font-family: "Newsreader", serif;
+  font-family: var(--font-family-base), serif;
   font-size: var(--font-size-base);
   font-weight: 400;
   line-height: 1.6;
@@ -265,7 +266,7 @@ header > div {
 
 header h1,
 header h1 a {
-  font-family: "Newsreader", serif;
+  font-family: var(--font-family-base), serif;
   font-weight: 600;
   font-size: 1.2em;
   line-height: 44px;
@@ -361,7 +362,7 @@ h3,
 .author-date,
 .mobile-toc-link,
 .toc-container h2 {
-  font-family: "Newsreader", serif;
+  font-family: var(--font-family-base), serif;
   font-weight: 400;
   line-height: 1.2;
 }


### PR DESCRIPTION
This change allows for custom CSS on the site so you can create `assets/css/custom.css` to add new styles or override existing styles.

For example:

```css
:root {
  --font-family-base: "Palatino", "Palatino Linotype";
}
```

If the file exists, it's linked to after `/css/styles.css`.

The base font is now controlled via `--font-family-base`.