### PR TITLE
Use author's X handle in X Cards meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,12 @@ copyright = "Copyright © 2025 Your Name. All rights reserved."
 theme = "dario"
 
 [params]
-  author = "Your Name" # the author of the site
   description = "A description of your site" # a description of your site that will be used in the meta tags
+
+  [params.author]
+    name = "Your Name" # the author of the site
+    email = "you@example.com" # the site author's email address
+    x = "@YourXHandle" # the site author's X handle
 ```
 
 To add intro text to your home page, create a file at `content/_index.md` with contents similar to the following:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ theme = "dario"
   [params.author]
     name = "Your Name" # the author of the site
     email = "you@example.com" # the site author's email address
-    x = "@YourXHandle" # the site author's X handle
+    twitter = "@YourXHandle" # the site author's X/Twitter handle
 ```
 
 To add intro text to your home page, create a file at `content/_index.md` with contents similar to the following:

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,19 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    {{- with site.Params.author }}
+        {{- if reflect.IsMap . }}
+            {{- with .name }}
+    <meta name="author" content="{{ . }}" />
+            {{- end }}
+        {{- else }}
+    <meta name="author" content="{{ . }}" />
+        {{- end }}
+    {{- end }}
+
+    <meta name="description" content="{{ .Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " ") | default .Site.Params.description | truncate 150 }}" />
+
     <title>{{ .Title | default .Site.Title }}</title>
 
     {{ if strings.HasSuffix .RelPermalink "/404.html" }}
@@ -12,9 +25,6 @@
 {{ partial "opengraph.html" . }}
         {{- end }}
     {{ end }}
-
-    <meta name="author" content="{{ .Site.Params.author }}" />
-    <meta name="description" content="{{ .Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " ") | default .Site.Params.description | truncate 150 }}" />
 
     <link rel="preload" href="{{ "fonts/Newsreader.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="{{ "fonts/Newsreader-italic.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -76,3 +76,10 @@
 <meta name="twitter:title" content="{{ $title }}" />
 <meta name="twitter:description" content="{{ $description }}" />
 <meta name="twitter:image" content="{{ $baseURL }}{{ $ogImageURL }}" />
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .x }}
+<meta name="twitter:creator" content="{{ . }}" />
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -78,7 +78,7 @@
 <meta name="twitter:image" content="{{ $baseURL }}{{ $ogImageURL }}" />
 {{- with site.Params.author }}
   {{- if reflect.IsMap . }}
-    {{- with .x }}
+    {{- with .twitter }}
 <meta name="twitter:creator" content="{{ . }}" />
     {{- end }}
   {{- end }}


### PR DESCRIPTION
This lets you set your X handle as well as email in `config.toml`.

The email is included in the RSS feed by the default template. In `opengraph.html` we use the X handle. The name is taken from `author.name` if `author` is a map, otherwise it's just the value of `author`.