### PR TITLE
Add support for non-standard meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ Set the `disableSocialMeta` parameter to turn off HTML tags related to [Open Gra
   disableSocialMeta = true
 ```
 
+If you wish to add your own non-standard meta tags for things like Bitcoin,
+PGP, and so on, you can add them in `layouts/partials/nonstdmeta.md`:
+
+```html
+<meta name="email" content="mail@example.com">
+<meta name="bitcoin" content="bc1...">
+
+<link rel="pgpkey" href="/pgp/key.asc">
+```
+
 ## Blog Posts
 
 Creating a blog post follows the same general process as most Hugo blogging themes.

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,4 +42,8 @@
     {{ end }}
 
     <script src="{{ "js/footnotes.js" | relURL }}" defer></script>
+
+    {{- if templates.Exists "partials/nonstdmeta.html" }}
+{{ partial "nonstdmeta.html" . }}
+    {{- end }}
 </head>


### PR DESCRIPTION
This patch adds support for additional non-standard meta tags.

Instructions in `README.md`.