### PR TITLE
Show date only if set explicitly

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,11 +2,11 @@
     <h1>{{ .Title }}</h1>
     <h4>{{ .Params.description }}</h4>
 
-    {{ if .Section }}
+    {{- if isset .Params "date" }}
     <p class="author-date">
         {{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}
     </p>
-    {{ end }}
+    {{- end }}
 
     {{- if not (.Param "disableAnchoredHeadings") }}
     {{- partial "anchored_headings.html" .Content -}}


### PR DESCRIPTION
This patch changes the logic for the date output in HTML so that the site owner can choose on which pages to show a date, regardless of the location of the page.

With the new logic, if the page's front matter has a `date` property, the HTML output contains the date.

Related: https://github.com/GrantBirki/dario/pull/26