### PR TITLE
Add disableFontPreload parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ You can add your own custom CSS in `assets/css/custom.css`:
 }
 ```
 
+If you override the default base font, you might also want to turn off font preloading:
+
+```toml
+[params]
+  disableFontPreload = true
+```
+
 To override the generated `404.html`, create `content/_404.md` with your customized text. For example, the following file contains a Hindi version of the default message:
 
 ```yaml

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,8 +26,10 @@
         {{- end }}
     {{ end }}
 
+    {{- if not .Site.Params.disableFontPreload }}
     <link rel="preload" href="{{ "fonts/Newsreader.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="{{ "fonts/Newsreader-italic.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />
+    {{- end }}
 
     <link rel="stylesheet" href="{{ "css/styles.css" | relURL }}" />
     {{- with resources.Get "css/custom.css" }}


### PR DESCRIPTION
This patch adds a `disableFontPreload` parameter for turning off font preloading, which is useful when the base font has been changed via `custom.css` and Newsreader is no longer in use.