### PR TITLE
Use language direction in templates

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{- .Site.Language.LanguageCode -}}">
+<html lang="{{- .Site.Language.LanguageCode -}}" dir="{{- .Site.Language.LanguageDirection | default "ltr" -}}">
 
 {{ partial "head.html" . }}
 


### PR DESCRIPTION
For right-to-left languages like Arabic, the `<html />` element must have `dir="rtl"` for text and other elements to appear facing in the right direction.

This patch uses the value of [`.Site.Language.LanguageDirection`](https://gohugo.io/configuration/languages/#language-settings) and defaults to `ltr`.

Note that this alone doesn't make everything work correctly for RTL languages, but it's necessary. In addition to this, you'd have to do some alignment changes in CSS via `custom.css`. This is up to the site owner to do correctly, but the provisions are there now.