### PR TITLE
"Blog Like" Landing Page Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ description: "A minimal web log." # The description of the home page that will b
 This is a minimal web log inspired by Dario Amodei's personal [website](https://darioamodei.com/). Add some more text here that will be displayed on your homepage (you can use markdown).
 ```
 
+> Note: In the front matter yaml above, you can also set `homePageIsPost: true` to hydrate the landing page like a blog post. This is an alternate way to view the home page and is somewhat experimental.
+
 ### Optional Settings
 
 By default, the theme shows a toggle for switching between light and dark modes. To follow the user's system preference instead, set the `useSystemColorScheme` parameter:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,11 +1,23 @@
 {{ define "main" }}
     {{- with .Site.GetPage "_index.md" }}
+        {{- if .Params.homePageIsPost }}
+        <h1>{{ .Title }}</h1>
+        <h4>{{ .Params.description }}</h4>
+        <p class="author-date">
+            <time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}
+        </p>
+
+        {{- if not (.Param "disableAnchoredHeadings") }}
+        {{- partial "anchored_headings.html" .Content -}}
+        {{- else }}{{ .Content }}{{ end }}
+        {{- else }}
         {{- $subtitle := .Params.subtitle }}
         {{- with .Content }}
         <section>
         <h1 class="smaller">{{ $subtitle }}</h1>
         {{ . }}
         </section>
+        {{- end }}
         {{- end }}
     {{- end }}
 


### PR DESCRIPTION
This PR makes it so that I can have a "blog-like" landing page based on a front matter variable called `homePageIsPost`.

This is a niche feature that I use on a personal site I'm working on. It is disable by default but when it is enabled, you can make your landing page kinda look like a blog post.

<img width="684" height="890" alt="Screenshot 2025-07-22 at 3 38 19 PM" src="https://github.com/user-attachments/assets/1b325fa7-323a-4223-8f72-17acdeae3236" />
