### PR TITLE
Remove optional self-closing slash in HTML

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,25 +1,25 @@
 <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {{- with site.Params.author }}
         {{- if reflect.IsMap . }}
             {{- with .name }}
-    <meta name="author" content="{{ . }}" />
+    <meta name="author" content="{{ . }}">
             {{- end }}
         {{- else }}
-    <meta name="author" content="{{ . }}" />
+    <meta name="author" content="{{ . }}">
         {{- end }}
     {{- end }}
 
-    <meta name="description" content="{{- .Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " " | replaceRE "^ +| +$" "") | default .Site.Params.description | truncate 150 -}}" />
+    <meta name="description" content="{{- .Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " " | replaceRE "^ +| +$" "") | default .Site.Params.description | truncate 150 -}}">
 
     <title>{{ .Title | default .Site.Title }}</title>
 
-    {{ if strings.HasSuffix .RelPermalink "/404.html" }}
-    <meta name="robots" content="noindex, nofollow" />
-    {{ else }}
-    <link rel="canonical" href="{{ .Permalink }}" />
+    {{- if strings.HasSuffix .RelPermalink "/404.html" }}
+    <meta name="robots" content="noindex, nofollow">
+    {{- else }}
+    <link rel="canonical" href="{{ .Permalink }}">
 
         {{- if not .Site.Params.disableSocialMeta }}
 {{ partial "opengraph.html" . }}
@@ -27,20 +27,20 @@
     {{- end }}
 
     {{- if not .Site.Params.disableFontPreload }}
-    <link rel="preload" href="{{ "fonts/Newsreader.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />
-    <link rel="preload" href="{{ "fonts/Newsreader-italic.woff2" | relURL }}" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="{{ "fonts/Newsreader.woff2" | relURL }}" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="{{ "fonts/Newsreader-italic.woff2" | relURL }}" as="font" type="font/woff2" crossorigin>
     {{- end }}
 
     {{- $defaultCSS := resources.Get "css/default.css" | minify | fingerprint }}
-    <link rel="stylesheet" href="{{ $defaultCSS.RelPermalink }}" integrity="{{ $defaultCSS.Data.Integrity }}" />
+    <link rel="stylesheet" href="{{ $defaultCSS.RelPermalink }}" integrity="{{ $defaultCSS.Data.Integrity }}">
     {{- with resources.Get "css/custom.css" }}
         {{- with . | minify | fingerprint }}
-    <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" />
+    <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}">
         {{- end }}
     {{- end }}
 
-    <link rel="icon" type="image/x-icon" href="{{ "favicon.ico" | relURL }}" />
-    <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | relURL }}" />
+    <link rel="icon" type="image/x-icon" href="{{ "favicon.ico" | relURL }}">
+    <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | relURL }}">
 
     {{- if not .Site.Params.useSystemColorScheme }}
     {{- $darkmodeJS := resources.Get "js/darkmode.js" | minify | fingerprint }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,12 +5,7 @@
         </h1>
         <div class="header-controls">
             <div class="toggle-switch">
-                <input
-                    type="checkbox"
-                    id="darkModeToggle"
-                    class="toggle-input"
-                    aria-label="Toggle dark mode"
-                />
+                <input type="checkbox" id="darkModeToggle" class="toggle-input" aria-label="Toggle dark mode">
                 <label for="darkModeToggle" class="toggle-label">
                     <span class="toggle-slider"></span>
                 </label>

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -61,25 +61,25 @@
 {{- end }}
 
 <!-- General Open Graph Meta Tags -->
-<meta property="og:title" content="{{ $title }}" />
-<meta property="og:description" content="{{ $description }}" />
-<meta property="og:image" content="{{ $baseURL }}{{ $ogImageURL }}" />
-<meta property="og:image:type" content={{- if strings.HasSuffix $ogImageURL ".svg" -}}"image/svg+xml"{{- else -}}"image/png"{{- end }} />
-<meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="630" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ $baseURL }}{{ .RelPermalink }}" />
-<meta property="og:locale" content="{{- site.Language.LanguageCode -}}" />
+<meta property="og:title" content="{{ $title }}">
+<meta property="og:description" content="{{ $description }}">
+<meta property="og:image" content="{{ $baseURL }}{{ $ogImageURL }}">
+<meta property="og:image:type" content={{- if strings.HasSuffix $ogImageURL ".svg" -}}"image/svg+xml"{{- else -}}"image/png"{{- end }}>
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ $baseURL }}{{ .RelPermalink }}">
+<meta property="og:locale" content="{{- site.Language.LanguageCode -}}">
 
 <!-- Twitter Cards -->
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:title" content="{{ $title }}" />
-<meta name="twitter:description" content="{{ $description }}" />
-<meta name="twitter:image" content="{{ $baseURL }}{{ $ogImageURL }}" />
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ $title }}">
+<meta name="twitter:description" content="{{ $description }}">
+<meta name="twitter:image" content="{{ $baseURL }}{{ $ogImageURL }}">
 {{- with site.Params.author }}
     {{- if reflect.IsMap . }}
         {{- with .twitter }}
-<meta name="twitter:creator" content="{{ . }}" />
+<meta name="twitter:creator" content="{{ . }}">
         {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
This is a bit opinionated.

In HTML5, for tags like `<meta>`, `<link>`, etc., the self-closing part (i.e. the `/` before the `>`) is optional. It just makes it less prone to error and more consistent if the code never uses this old XHTML style.