### PR TITLE
Move some code to layouts/partials/objects/

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,9 +6,10 @@
     <meta name="author" content="{{ . }}">
     {{- end }}
 
-    <meta name="description" content="{{- .Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " " | replaceRE "^ +| +$" "") | default .Site.Params.description | truncate 150 -}}">
+    {{- $page := partial "objects/page.html" . }}
+    <meta name="description" content="{{- $page.description -}}">
 
-    <title>{{ .Title | default .Site.Title }}</title>
+    <title>{{ $page.title }}</title>
 
     {{- if strings.HasSuffix .RelPermalink "/404.html" }}
     <meta name="robots" content="noindex, nofollow">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,14 +2,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    {{- with site.Params.author }}
-        {{- if reflect.IsMap . }}
-            {{- with .name }}
+    {{- with (partial "objects/author.html" .).name }}
     <meta name="author" content="{{ . }}">
-            {{- end }}
-        {{- else }}
-    <meta name="author" content="{{ . }}">
-        {{- end }}
     {{- end }}
 
     <meta name="description" content="{{- .Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " " | replaceRE "^ +| +$" "") | default .Site.Params.description | truncate 150 -}}">

--- a/layouts/partials/objects/author.html
+++ b/layouts/partials/objects/author.html
@@ -1,0 +1,21 @@
+{{ $name := "" }}
+{{ $email := "" }}
+{{ $twitter := "" }}
+
+{{ with site.Params.author }}
+    {{ if reflect.IsMap . }}
+        {{ with .name }}
+            {{ $name = . }}
+        {{ end }}
+        {{ with .email }}
+            {{ $email = . }}
+        {{ end }}
+        {{ with .twitter }}
+            {{ $twitter = . }}
+        {{ end }}
+    {{ else }}
+        {{ $name = . }}
+    {{ end }}
+{{ end }}
+
+{{ return dict "name" $name "email" $email "twitter" $twitter }}

--- a/layouts/partials/objects/page.html
+++ b/layouts/partials/objects/page.html
@@ -1,12 +1,27 @@
 {{ $title := .Title | default .Site.Title }}
 
 {{ $_summary := .Summary }}
+
+{{/* Strip HTML */}}
 {{ $_summary = $_summary | plainify }}
+
+{{/* Unescape entities like '&lt;', '&rsquo;', etc.
+   *
+   * Some of these like '<' will be re-escaped in the replaceRE operations,
+   * whereas others like '’' shouldn't be in order to keep the result
+   * SVG-friendly.
+   */}}
 {{ $_summary = $_summary | htmlUnescape }}
+
+{{/* Collapse whitespace */}}
 {{ $_summary = $_summary | replaceRE "\\s+" " " }}
+
+{{/* Trim */}}
 {{ $_summary = $_summary | replaceRE "^ +| +$" "" }}
 
 {{ $description := .Description | default $_summary | default .Site.Params.description }}
+
+{{/* Truncate to a reasonable SEO-friendly length */}}
 {{ $description = $description | truncate 150 }}
 
 {{ return dict "title" $title "description" $description }}

--- a/layouts/partials/objects/page.html
+++ b/layouts/partials/objects/page.html
@@ -1,0 +1,12 @@
+{{ $title := .Title | default .Site.Title }}
+
+{{ $_summary := .Summary }}
+{{ $_summary = $_summary | plainify }}
+{{ $_summary = $_summary | htmlUnescape }}
+{{ $_summary = $_summary | replaceRE "\\s+" " " }}
+{{ $_summary = $_summary | replaceRE "^ +| +$" "" }}
+
+{{ $description := .Description | default $_summary | default .Site.Params.description }}
+{{ $description = $description | truncate 150 }}
+
+{{ return dict "title" $title "description" $description }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -76,10 +76,6 @@
 <meta name="twitter:title" content="{{ $title }}">
 <meta name="twitter:description" content="{{ $description }}">
 <meta name="twitter:image" content="{{ $baseURL }}{{ $ogImageURL }}">
-{{- with site.Params.author }}
-    {{- if reflect.IsMap . }}
-        {{- with .twitter }}
+{{- with (partial "objects/author.html" .).twitter }}
 <meta name="twitter:creator" content="{{ . }}">
-        {{- end }}
-    {{- end }}
 {{- end }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -1,6 +1,6 @@
-{{- $title := .Params.ogTitle | default .Title | default site.Title -}}
-
-{{- $description := .Params.ogDescription | default .Description | default (.Summary | plainify | htmlUnescape | replaceRE "\\s+" " " | replaceRE "^ +| +$" "") | default site.Params.description | truncate 150 -}}
+{{- $page := partial "objects/page.html" . -}}
+{{- $title := .Params.ogTitle | default $page.title -}}
+{{- $description := .Params.ogDescription | default $page.description -}}
 
 {{- /* Handle base URL for local dev vs production */ -}}
 {{- $baseURL := .Site.BaseURL | strings.TrimSuffix "/" }}


### PR DESCRIPTION
This change moves some code to `layouts/partials/objects/`:

1. Author information is in `author.html`
2. Page information (title and description) is in `page.html`

These "object" partials return dictionaries so the including file can use whatever properties it needs.