### PR TITLE
Add unsafeInlineCSS and unsafeInlineJS parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,13 @@ Inlining all styles and scripts directly within the HTML can simplify deployment
 
 ```toml
 [params]
-  inlineCSS = true
-  inlineJS = true
+  unsafeInlineCSS = true
+  unsafeInlineJS = true
 ```
 
 Whether this is optimal depends on the site's structure, server-side [`Cache-Control` settings](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching), and other factors.
+
+It's also important to note that inlining of CSS and JavaScript comes with **security risks** and should generally be avoided.
 
 To override the generated `404.html`, create `content/_404.md` with your customized text. For example, the following file contains a Hindi version of the default message:
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ If you override the default base font, you might also want to turn off font prel
   disableFontPreload = true
 ```
 
-Inlining all styles and scripts directly within the HTML can simplify deployment and speed up initial page load:
+Inlining all styles and scripts directly within the HTML can simplify deployment and improve initial page load speed, as everything is bundled into a single HTML file. The trade-off is reduced caching efficiency, since CSS and JavaScript are no longer separate cacheable files. By default, this project does not inline CSS or JavaScript, but you can enable it with the following settings:
 
 ```toml
 [params]
@@ -172,7 +172,7 @@ Inlining all styles and scripts directly within the HTML can simplify deployment
 
 Whether this is optimal depends on the site's structure, server-side [`Cache-Control` settings](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching), and other factors.
 
-It's also important to note that inlining of CSS and JavaScript comes with **security risks** and should generally be avoided.
+It's also important to note that inlining of CSS and JavaScript comes with **security risks** and is generally discouraged.
 
 To override the generated `404.html`, create `content/_404.md` with your customized text. For example, the following file contains a Hindi version of the default message:
 

--- a/README.md
+++ b/README.md
@@ -162,13 +162,15 @@ If you override the default base font, you might also want to turn off font prel
   disableFontPreload = true
 ```
 
-You can inline all styles and scripts directly within the HTML instead of loading them as separate files:
+Inlining all styles and scripts directly within the HTML can simplify deployment and speed up initial page load:
 
 ```toml
 [params]
   inlineCSS = true
   inlineJS = true
 ```
+
+Whether this is optimal depends on the site's structure, server-side [`Cache-Control` settings](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching), and other factors.
 
 To override the generated `404.html`, create `content/_404.md` with your customized text. For example, the following file contains a Hindi version of the default message:
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ If you override the default base font, you might also want to turn off font prel
   disableFontPreload = true
 ```
 
+You can inline all styles and scripts directly within the HTML instead of loading them as separate files:
+
+```toml
+[params]
+  inlineCSS = true
+  inlineJS = true
+```
+
 To override the generated `404.html`, create `content/_404.md` with your customized text. For example, the following file contains a Hindi version of the default message:
 
 ```yaml

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -67,4 +67,8 @@ function initDarkMode() {
 // Since this script may be either loaded as an external JS file or
 // inlined within HTML, all code must run only on or after the
 // DOMContentLoaded event.
-document.addEventListener("DOMContentLoaded", initDarkMode);
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initDarkMode);
+} else {
+  initDarkMode();
+}

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -64,9 +64,4 @@ function initDarkMode() {
   });
 }
 
-// Use immediate listener setup
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", initDarkMode);
-} else {
-  initDarkMode();
-}
+document.addEventListener("DOMContentLoaded", initDarkMode);

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -64,4 +64,7 @@ function initDarkMode() {
   });
 }
 
+// Since this script may be either loaded as an external JS file or
+// inlined within HTML, all code must run only on or after the
+// DOMContentLoaded event.
 document.addEventListener("DOMContentLoaded", initDarkMode);

--- a/assets/js/footnotes.js
+++ b/assets/js/footnotes.js
@@ -1,5 +1,8 @@
 "use strict";
 
+// Since this script may be either loaded as an external JS file or
+// inlined within HTML, all code must run only on or after the
+// DOMContentLoaded event.
 document.addEventListener("DOMContentLoaded", () => {
   const TOOLTIP_DELAY = 500;
   const DISMISS_DELAY = 300;

--- a/assets/js/footnotes.js
+++ b/assets/js/footnotes.js
@@ -1,9 +1,6 @@
 "use strict";
 
-// Since this script may be either loaded as an external JS file or
-// inlined within HTML, all code must run only on or after the
-// DOMContentLoaded event.
-document.addEventListener("DOMContentLoaded", () => {
+function initFootnotes() {
   const TOOLTIP_DELAY = 500;
   const DISMISS_DELAY = 300;
   const MOUSE_TOLERANCE = 5;
@@ -160,4 +157,13 @@ document.addEventListener("DOMContentLoaded", () => {
       timeout = setTimeout(() => func.apply(this, args), wait);
     };
   }
-});
+}
+
+// Since this script may be either loaded as an external JS file or
+// inlined within HTML, all code must run only on or after the
+// DOMContentLoaded event.
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initFootnotes);
+} else {
+  initFootnotes();
+}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,24 +26,52 @@
     <link rel="preload" href="{{ "fonts/Newsreader-italic.woff2" | relURL }}" as="font" type="font/woff2" crossorigin>
     {{- end }}
 
+    {{- $inlineCSS := .Site.Params.inlineCSS }}
+
     {{- $defaultCSS := resources.Get "css/default.css" | minify | fingerprint }}
+    {{- if $inlineCSS }}
+    <style>
+{{ $defaultCSS.Content | safeCSS }}
+    </style>
+    {{- else }}
     <link rel="stylesheet" href="{{ $defaultCSS.RelPermalink }}" integrity="{{ $defaultCSS.Data.Integrity }}">
+    {{- end }}
     {{- with resources.Get "css/custom.css" }}
         {{- with . | minify | fingerprint }}
+            {{- if $inlineCSS }}
+    <style>
+{{ .Content | safeCSS }}
+    </style>
+            {{- else }}
     <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}">
+            {{- end }}
         {{- end }}
     {{- end }}
 
     <link rel="icon" type="image/x-icon" href="{{ "favicon.ico" | relURL }}">
     <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | relURL }}">
 
+    {{- $inlineJS := .Site.Params.inlineJS }}
+
     {{- if not .Site.Params.useSystemColorScheme }}
-    {{- $darkmodeJS := resources.Get "js/darkmode.js" | minify | fingerprint }}
+        {{- $darkmodeJS := resources.Get "js/darkmode.js" | minify | fingerprint }}
+        {{- if $inlineJS }}
+    <script>
+{{ $darkmodeJS.Content | safeJS }}
+    </script>
+        {{- else }}
     <script src="{{ $darkmodeJS.RelPermalink }}" integrity="{{ $darkmodeJS.Data.Integrity }}" defer></script>
+        {{- end }}
     {{- end }}
 
     {{- $footnotesJS := resources.Get "js/footnotes.js" | minify | fingerprint }}
+    {{- if $inlineJS }}
+    <script>
+{{ $footnotesJS.Content | safeJS }}
+    </script>
+    {{- else }}
     <script src="{{ $footnotesJS.RelPermalink }}" integrity="{{ $footnotesJS.Data.Integrity }}" defer></script>
+    {{- end }}
 
     {{- if templates.Exists "partials/nonstdmeta.html" }}
 {{ partial "nonstdmeta.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -57,7 +57,9 @@
         {{- $darkmodeJS := resources.Get "js/darkmode.js" | minify | fingerprint }}
         {{- if $inlineJS }}
     <script>
+      document.addEventListener("DOMContentLoaded", () => {
 {{ $darkmodeJS.Content | safeJS }}
+      });
     </script>
         {{- else }}
     <script src="{{ $darkmodeJS.RelPermalink }}" integrity="{{ $darkmodeJS.Data.Integrity }}" defer></script>
@@ -67,7 +69,9 @@
     {{- $footnotesJS := resources.Get "js/footnotes.js" | minify | fingerprint }}
     {{- if $inlineJS }}
     <script>
+      document.addEventListener("DOMContentLoaded", () => {
 {{ $footnotesJS.Content | safeJS }}
+      });
     </script>
     {{- else }}
     <script src="{{ $footnotesJS.RelPermalink }}" integrity="{{ $footnotesJS.Data.Integrity }}" defer></script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,10 +26,10 @@
     <link rel="preload" href="{{ "fonts/Newsreader-italic.woff2" | relURL }}" as="font" type="font/woff2" crossorigin>
     {{- end }}
 
-    {{- $inlineCSS := .Site.Params.inlineCSS }}
+    {{- $unsafeInlineCSS := .Site.Params.unsafeInlineCSS }}
 
     {{- $defaultCSS := resources.Get "css/default.css" | minify | fingerprint }}
-    {{- if $inlineCSS }}
+    {{- if $unsafeInlineCSS }}
     <style>
 {{ $defaultCSS.Content | safeCSS }}
     </style>
@@ -38,7 +38,7 @@
     {{- end }}
     {{- with resources.Get "css/custom.css" }}
         {{- with . | minify | fingerprint }}
-            {{- if $inlineCSS }}
+            {{- if $unsafeInlineCSS }}
     <style>
 {{ .Content | safeCSS }}
     </style>
@@ -51,11 +51,11 @@
     <link rel="icon" type="image/x-icon" href="{{ "favicon.ico" | relURL }}">
     <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | relURL }}">
 
-    {{- $inlineJS := .Site.Params.inlineJS }}
+    {{- $unsafeInlineJS := .Site.Params.unsafeInlineJS }}
 
     {{- if not .Site.Params.useSystemColorScheme }}
         {{- $darkmodeJS := resources.Get "js/darkmode.js" | minify | fingerprint }}
-        {{- if $inlineJS }}
+        {{- if $unsafeInlineJS }}
     <script>
       document.addEventListener("DOMContentLoaded", () => {
 {{ $darkmodeJS.Content | safeJS }}
@@ -67,7 +67,7 @@
     {{- end }}
 
     {{- $footnotesJS := resources.Get "js/footnotes.js" | minify | fingerprint }}
-    {{- if $inlineJS }}
+    {{- if $unsafeInlineJS }}
     <script>
       document.addEventListener("DOMContentLoaded", () => {
 {{ $footnotesJS.Content | safeJS }}


### PR DESCRIPTION
The `unsafeInlineCSS` and `unsafeInlineJS` parameters enable inlining of CSS and JS respectively.

This can be used for simplifying deployment and reducing the number of HTTP requests, especially for the initial load of the landing page, with the tradeoff that subsequent page loads are a bit slower due to a larger HTML file size.

`README.md` contains instructions.