### PR TITLE
Add page kind class to <html>

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{- .Site.Language.LanguageCode -}}" dir="{{- .Site.Language.LanguageDirection | default "ltr" -}}">
+<html lang="{{- .Site.Language.LanguageCode -}}" dir="{{- .Site.Language.LanguageDirection | default "ltr" -}}" class="kind-{{ .Kind }}">
 
 {{ partial "head.html" . }}
 


### PR DESCRIPTION
This change adds a page kind class to the `<html>` element to allow for targeting specific kinds of pages in CSS. For example, the home page has `home-kind`. A declaration like `.home-kind ul > li { ... }` would apply to list items on the home page.