### PR TITLE
Implement colorScheme=toggle|system|dark|light

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ By default, the theme shows a toggle for switching between light and dark modes.
   colorScheme = 'system'
 ```
 
-You can also set it to `'light'` or `'dark'` to keep it fixed.
+You can also set it to `'light'` or `'dark'` to keep it fixed. The default behavior is to have it set as `'toggle'` which displays a toggle and on first page load it defaults to the user's system preference.
 
 The home page shows the top-level section with the most pages by default. To override this, set `mainSections` to select specific sections:
 

--- a/README.md
+++ b/README.md
@@ -128,12 +128,14 @@ This is a minimal web log inspired by Dario Amodei's personal [website](https://
 
 ### Optional Settings
 
-By default, the theme shows a toggle for switching between light and dark modes. To follow the user's system preference instead, set the `useSystemColorScheme` parameter:
+By default, the theme shows a toggle for switching between light and dark modes. To follow the user's system preference instead, set the `colorScheme` parameter to `'system'`:
 
 ```toml
 [params]
-  useSystemColorScheme = true
+  colorScheme = 'system'
 ```
+
+You can also set it to `'light'` or `'dark'` to keep it fixed.
 
 The home page shows the top-level section with the most pages by default. To override this, set `mainSections` to select specific sections:
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,8 @@
 <!doctype html>
-<html lang="{{- .Site.Language.LanguageCode -}}" dir="{{- .Site.Language.LanguageDirection | default "ltr" -}}" class="kind-{{ .Kind }}">
+<html lang="{{- .Site.Language.LanguageCode -}}" dir="{{- .Site.Language.LanguageDirection | default "ltr" -}}" class="kind-{{ .Kind }}
+{{- if eq .Site.Params.colorScheme "dark" }} dark-mode-on
+{{- else if eq .Site.Params.colorScheme "light" }} dark-mode-off
+{{- end }}">
 
 {{ partial "head.html" . }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,7 +37,7 @@
     <link rel="icon" type="image/x-icon" href="{{ "favicon.ico" | relURL }}">
     <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | relURL }}">
 
-    {{- if not .Site.Params.useSystemColorScheme }}
+    {{- if or (not .Site.Params.colorScheme) (eq .Site.Params.colorScheme "toggle") }}
     {{- $darkmodeJS := resources.Get "js/darkmode.js" | minify | fingerprint }}
     <script src="{{ $darkmodeJS.RelPermalink }}" integrity="{{ $darkmodeJS.Data.Integrity }}" defer></script>
     {{- end }}


### PR DESCRIPTION
`useSystemColorScheme=false|true` is now `colorScheme=toggle|system|dark|light`. This gives you the option of keeping the color scheme fixed. We do this by setting the `dark-mode-on` or `dark-mode-off` CSS classes in HTML itself.