### PR TITLE
Add script-driven CI and fix upstream CSS/OG regressions

### DIFF
--- a/.github/.hugo-version
+++ b/.github/.hugo-version
@@ -1,0 +1,1 @@
+v0.155.3+extended+withdeploy

--- a/.github/.hugo-version
+++ b/.github/.hugo-version
@@ -1,1 +1,1 @@
-v0.155.3+extended+withdeploy
+0.156.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+
+      - name: bootstrap
+        run: script/bootstrap
+
+      - name: build
+        run: script/build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: lint
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+
+      - name: bootstrap
+        run: script/bootstrap
+
+      - name: lint
+        run: script/lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+
+      - name: bootstrap
+        run: script/bootstrap
+
+      - name: test
+        run: script/test

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ tmp/
 
 # Local development files
 *.local
+
+# Hugo build artifacts
+public/
+resources/_gen/
+.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # dario 🖊️
 
+[![lint](https://github.com/GrantBirki/dario/actions/workflows/lint.yml/badge.svg)](https://github.com/GrantBirki/dario/actions/workflows/lint.yml)
+[![test](https://github.com/GrantBirki/dario/actions/workflows/test.yml/badge.svg)](https://github.com/GrantBirki/dario/actions/workflows/test.yml)
+[![build](https://github.com/GrantBirki/dario/actions/workflows/build.yml/badge.svg)](https://github.com/GrantBirki/dario/actions/workflows/build.yml)
+
 A minimal hugo theme inspired by Dario Amodei's personal [website](https://darioamodei.com/). It is designed to be as minimal, performant, and as elegant as possible for reading.
 
 View the [live demo](https://log.birki.io) to see what it looks like ([source code](https://github.com/GrantBirki/dario)).
@@ -11,6 +15,19 @@ View the [live demo](https://log.birki.io) to see what it looks like ([source co
 This theme is designed to be minimal and the page speed insights are as follows:
 
 ![100](https://raw.githubusercontent.com/GrantBirki/dario/main/docs/assets/100.png)
+
+## Development
+
+This repository follows the ["scripts to rule them all"](https://github.blog/engineering/scripts-to-rule-them-all/) pattern:
+
+```bash
+script/bootstrap
+script/lint
+script/test
+script/build
+```
+
+CI executes these same scripts directly.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Set the `disableSocialMeta` parameter to turn off HTML tags related to [Open Gra
 ```
 
 If you wish to add your own non-standard meta tags for things like Bitcoin,
-PGP, and so on, you can add them in `layouts/partials/nonstdmeta.md`:
+PGP, and so on, you can add them in `layouts/partials/nonstdmeta.html`:
 
 ```html
 <meta name="email" content="mail@example.com">

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -22,6 +22,7 @@
   --content-max-inline-size: 620px;
   --content-padding: 20px;
   --focus-color: #0066cc;
+  --muted-text-color: #666666;
 }
 
 body,
@@ -55,6 +56,7 @@ header h1 a {
   --invert-percentage: 100%;
   --code-bg: rgb(55, 56, 62);
   --hljs-bg: rgb(46, 46, 51);
+  --muted-text-color: #b3b3b3;
 }
 
 .dark-mode-off:root {
@@ -76,6 +78,7 @@ header h1 a {
   --invert-percentage: 0%;
   --code-bg: rgb(223, 223, 223);
   --hljs-bg: rgb(28, 29, 33);
+  --muted-text-color: #666666;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -98,6 +101,7 @@ header h1 a {
     --invert-percentage: 100%;
     --code-bg: rgb(55, 56, 62);
     --hljs-bg: rgb(46, 46, 51);
+    --muted-text-color: #b3b3b3;
   }
 }
 
@@ -121,6 +125,7 @@ header h1 a {
     --invert-percentage: 0%;
     --code-bg: rgb(223, 223, 223);
     --hljs-bg: rgb(28, 29, 33);
+    --muted-text-color: #666666;
   }
 }
 
@@ -196,6 +201,10 @@ h6:hover .anchor {
   opacity: 0.5;
 }
 
+.anchor {
+  display: none;
+}
+
 a {
   color: inherit;
   text-decoration: underline;
@@ -238,7 +247,7 @@ header > div {
   box-sizing: border-box;
 }
 
-@media (min-inline-size: 1076px) {
+@media (min-width: 1076px) {
   body.has-toc .content-wrapper,
   body.has-toc header > div {
     max-inline-size: var(--content-max-inline-size);
@@ -356,6 +365,11 @@ p a:hover {
   background-color: var(--bg-color);
 }
 
+.toggle-input:focus-visible + .toggle-label {
+  outline: 2px solid var(--focus-color);
+  outline-offset: 2px;
+}
+
 /* Typography */
 h1,
 h2,
@@ -407,7 +421,7 @@ center {
 }
 
 /* Mobile Typography */
-@media (max-inline-size: 1076px) {
+@media (max-width: 1076px) {
   h1 {
     font-size: 2.4em;
   }
@@ -424,7 +438,7 @@ center {
 .author-date {
   font-weight: 400;
   font-size: 0.9em;
-  color: #767676;
+  color: var(--muted-text-color);
   margin-block-start: 2em;
   margin-block-end: 0em;
   line-height: 1.4;
@@ -453,7 +467,7 @@ hr:after {
   text-align: center;
 }
 
-@media (min-inline-size: 1400px) {
+@media (min-width: 1400px) {
   .content-wrapper,
   header > div {
     max-inline-size: var(--content-max-inline-size);

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -2,16 +2,16 @@
   font-family: "Newsreader";
   font-style: normal;
   font-weight: 200 800;
-  font-display: block;
-  src: url("/fonts/Newsreader.woff2") format("woff2");
+  font-display: swap;
+  src: url("../fonts/Newsreader.woff2") format("woff2");
 }
 
 @font-face {
   font-family: "Newsreader";
   font-style: italic;
   font-weight: 200 800;
-  font-display: block;
-  src: url("/fonts/Newsreader-italic.woff2") format("woff2");
+  font-display: swap;
+  src: url("../fonts/Newsreader-italic.woff2") format("woff2");
 }
 
 :root {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
 {{ partial "head.html" . }}
 
 <body>
-{{ partial "header.html" . }}
+{{ partialCached "header.html" . .Site.Language.Lang }}
 
     <main class="content-wrapper">
         <article class="content-container">
@@ -17,7 +17,7 @@
         </article>
     </main>
 
-{{ partial "footer.html" . }}
+{{ partialCached "footer.html" . .Site.Language.Lang now.Year }}
 </body>
 
 </html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,13 +6,5 @@
     <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
     {{- end }}
 
-    {{- if not (.Param "disableAnchoredHeadings") }}
-
-{{ partial "anchored_headings.html" .Content }}
-
-    {{- else }}
-
 {{ .Content }}
-
-    {{- end }}
 {{- end }}

--- a/layouts/_markup/render-heading.html
+++ b/layouts/_markup/render-heading.html
@@ -1,0 +1,3 @@
+{{- $disableAnchoredHeadings := .Page.Param "disableAnchoredHeadings" -}}
+{{- $anchor := .Anchor | safeURL -}}
+<h{{ .Level }} id="{{ .Anchor }}">{{ .Text }}{{- if not $disableAnchoredHeadings -}}<a class="anchor" aria-hidden="true" href="#{{ $anchor }}">#</a>{{- end -}}</h{{ .Level }}>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,15 +5,7 @@
     <h4>{{ .Params.description }}</h4>
     <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
 
-            {{- if not (.Param "disableAnchoredHeadings") }}
-
-{{ partial "anchored_headings.html" .Content }}
-
-            {{- else }}
-
 {{ .Content }}
-
-            {{- end }}
         {{- else }}
             {{- $subtitle := .Params.subtitle }}
             {{- with .Content }}

--- a/layouts/partials/anchored_headings.html
+++ b/layouts/partials/anchored_headings.html
@@ -1,2 +1,2 @@
 {{- /* formats .Content headings by adding an anchor */ -}}
-{{ . | replaceRE "(<h[1-6] id=\"([^\"]+)\".+)(</h[1-6]+>)" "${1}<a hidden class=\"anchor\" aria-hidden=\"true\" href=\"#${2}\">#</a>${3}" | safeHTML }}
+{{ . | replaceRE "(<h[1-6] id=\"([^\"]+)\".+)(</h[1-6]+>)" "${1}<a class=\"anchor\" aria-hidden=\"true\" href=\"#${2}\">#</a>${3}" | safeHTML }}

--- a/layouts/partials/anchored_headings.html
+++ b/layouts/partials/anchored_headings.html
@@ -1,2 +1,0 @@
-{{- /* formats .Content headings by adding an anchor */ -}}
-{{ . | replaceRE "(<h[1-6] id=\"([^\"]+)\".+)(</h[1-6]+>)" "${1}<a class=\"anchor\" aria-hidden=\"true\" href=\"#${2}\">#</a>${3}" | safeHTML }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,11 +2,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    {{- with (partial "objects/author.html" .).name }}
+    {{- $author := partialCached "objects/author.html" . .Site.Language.Lang -}}
+    {{- with $author.name }}
     <meta name="author" content="{{ . }}">
     {{- end }}
 
-    {{- $page := partial "objects/page.html" . }}
+    {{- $page := partialCached "objects/page.html" . .RelPermalink -}}
     <meta name="description" content="{{- $page.description -}}">
     <title>{{ $page.title }}</title>
 
@@ -22,7 +23,6 @@
 
     {{- if not .Site.Params.disableFontPreload }}
     <link rel="preload" href="{{ "fonts/Newsreader.woff2" | relURL }}" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="{{ "fonts/Newsreader-italic.woff2" | relURL }}" as="font" type="font/woff2" crossorigin>
     {{- end }}
 
     {{- $defaultCSS := resources.Get "css/default.css" | minify | fingerprint }}
@@ -45,8 +45,12 @@
     <script src="{{ $darkmodeJS.RelPermalink }}" integrity="{{ $darkmodeJS.Data.Integrity }}" defer></script>
     {{- end }}
 
-    {{- $footnotesJS := resources.Get "js/footnotes.js" | minify | fingerprint }}
+    {{- with .Content }}
+        {{- if or (in . "id=\"fnref") (in . "class=\"footnote-ref\"") }}
+            {{- $footnotesJS := resources.Get "js/footnotes.js" | minify | fingerprint }}
     <script src="{{ $footnotesJS.RelPermalink }}" integrity="{{ $footnotesJS.Data.Integrity }}" defer></script>
+        {{- end }}
+    {{- end }}
 
     {{- if templates.Exists "partials/nonstdmeta.html" }}
 {{ partial "nonstdmeta.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,8 +33,12 @@
         {{- end }}
     {{- end }}
 
+    {{- if fileExists "static/favicon.ico" }}
     <link rel="icon" type="image/x-icon" href="{{ "favicon.ico" | relURL }}">
+    {{- end }}
+    {{- if fileExists "static/apple-touch-icon.png" }}
     <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | relURL }}">
+    {{- end }}
 
     {{- if or (not .Site.Params.colorScheme) (eq .Site.Params.colorScheme "toggle") }}
     {{- $darkmodeJS := resources.Get "js/darkmode.js" | minify | fingerprint }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -11,12 +11,10 @@
 {{- end }}
 
 {{- $uniqueName := "" }}
-{{- $isDefault := false }}
 {{- with .File }}
     {{- $uniqueName = printf "og/og-image-%s.svg" .UniqueID }}
 {{- else }}
-    {{- $uniqueName = "default.png" }}
-    {{- $isDefault = true }}
+    {{- $uniqueName = printf "og/og-image-%s.svg" (md5 .RelPermalink) }}
 {{- end }}
 
 {{- $svg := printf `
@@ -44,20 +42,16 @@
             </div>
         </foreignObject>
     </svg>
-    ` ($title | htmlEscape) $description | safeHTML }}
+    ` ($title | htmlEscape) ($description | htmlEscape) | safeHTML }}
 
 {{- $generatedSVG := resources.FromString $uniqueName $svg | resources.ExecuteAsTemplate $uniqueName . -}}
 
 {{- /* Determine which image URL to use */ -}}
 {{- $ogImageURL := "" }}
-{{- if $isDefault }}
-    {{- $ogImageURL = "/default.png" }}
+{{- with .Params.ogImage }}
+    {{- $ogImageURL = . }}
 {{- else }}
-    {{- with .Params.ogImage }}
-        {{- $ogImageURL = . }}
-    {{- else }}
-        {{- $ogImageURL = $generatedSVG.RelPermalink }}
-    {{- end }}
+    {{- $ogImageURL = $generatedSVG.RelPermalink }}
 {{- end }}
 
 <!-- General Open Graph Meta Tags -->

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -1,14 +1,6 @@
-{{- $page := partial "objects/page.html" . -}}
+{{- $page := partialCached "objects/page.html" . .RelPermalink -}}
 {{- $title := .Params.ogTitle | default $page.title -}}
 {{- $description := .Params.ogDescription | default $page.description -}}
-
-{{- /* Handle base URL for local dev vs production */ -}}
-{{- $baseURL := .Site.BaseURL | strings.TrimSuffix "/" }}
-{{- if not (strings.Contains $baseURL "localhost") }}
-    {{- if not (strings.HasPrefix $baseURL "https://") }}
-        {{- $baseURL = replace $baseURL "http://" "https://" }}
-    {{- end }}
-{{- end }}
 
 {{- $uniqueName := "" }}
 {{- with .File }}
@@ -25,7 +17,7 @@
             }
             @font-face {
               font-family: 'Newsreader';
-              src: url('/fonts/Newsreader.woff2') format('woff2');
+              src: url('../fonts/Newsreader.woff2') format('woff2');
             }
             .title, .description {
               font-family: 'Newsreader', serif;
@@ -47,29 +39,32 @@
 {{- $generatedSVG := resources.FromString $uniqueName $svg | resources.ExecuteAsTemplate $uniqueName . -}}
 
 {{- /* Determine which image URL to use */ -}}
-{{- $ogImageURL := "" }}
+{{- $ogImageURL := $generatedSVG.Permalink }}
 {{- with .Params.ogImage }}
-    {{- $ogImageURL = . }}
-{{- else }}
-    {{- $ogImageURL = $generatedSVG.RelPermalink }}
+    {{- if or (strings.HasPrefix . "http://") (strings.HasPrefix . "https://") (strings.HasPrefix . "//") }}
+        {{- $ogImageURL = . }}
+    {{- else }}
+        {{- $ogImageURL = . | absURL }}
+    {{- end }}
 {{- end }}
 
 <!-- General Open Graph Meta Tags -->
 <meta property="og:title" content="{{ $title }}">
 <meta property="og:description" content="{{ $description }}">
-<meta property="og:image" content="{{ $baseURL }}{{ $ogImageURL }}">
+<meta property="og:image" content="{{ $ogImageURL }}">
 <meta property="og:image:type" content={{- if strings.HasSuffix $ogImageURL ".svg" -}}"image/svg+xml"{{- else -}}"image/png"{{- end }}>
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:type" content="website">
-<meta property="og:url" content="{{ $baseURL }}{{ .RelPermalink }}">
+<meta property="og:url" content="{{ .Permalink }}">
 <meta property="og:locale" content="{{- site.Language.LanguageCode -}}">
 
 <!-- Twitter Cards -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ $title }}">
 <meta name="twitter:description" content="{{ $description }}">
-<meta name="twitter:image" content="{{ $baseURL }}{{ $ogImageURL }}">
-{{- with (partial "objects/author.html" .).twitter }}
+<meta name="twitter:image" content="{{ $ogImageURL }}">
+{{- $author := partialCached "objects/author.html" . .Site.Language.Lang -}}
+{{- with $author.twitter }}
 <meta name="twitter:creator" content="{{ . }}">
 {{- end }}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -72,10 +72,9 @@ install_hugo_for_ci() {
   expected_version="$(read_hugo_version)"
   expected_semver="$(normalize_semver "$expected_version")"
   installed_semver="$(hugo_installed_semver || true)"
+  echo -e "${BLUE}Installing vendored Hugo version:${OFF} ${PURPLE}${expected_semver}${OFF}"
   if [[ -n "$installed_semver" ]]; then
-    warn "CI install is pinned; replacing local Hugo ${installed_semver} with vendored ${expected_semver}"
-  else
-    warn "hugo not found; installing vendored version ${expected_semver}"
+    echo -e "${BLUE}Detected preinstalled Hugo:${OFF} ${PURPLE}${installed_semver}${OFF}"
   fi
 
   case "$OSTYPE" in

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,7 +4,102 @@ set -euo pipefail
 
 source script/env "$@"
 
-install_hugo_linux() {
+HUGO_VERSION_FILE="$DIR/.github/.hugo-version"
+
+read_hugo_version_spec() {
+  [[ -f "$HUGO_VERSION_FILE" ]] || die "missing Hugo version file: $HUGO_VERSION_FILE"
+  local version
+  version="$(tr -d '[:space:]' < "$HUGO_VERSION_FILE")"
+  [[ -n "$version" ]] || die "Hugo version file is empty: $HUGO_VERSION_FILE"
+  printf '%s' "$version"
+}
+
+hugo_semver_from_spec() {
+  local spec="$1"
+  spec="${spec#v}"
+  printf '%s' "${spec%%+*}"
+}
+
+hugo_asset_prefix_from_spec() {
+  local spec="$1"
+  if [[ "$spec" == *"+extended+withdeploy"* ]]; then
+    printf 'hugo_extended_withdeploy'
+    return
+  fi
+  if [[ "$spec" == *"+extended"* ]]; then
+    printf 'hugo_extended'
+    return
+  fi
+  printf 'hugo'
+}
+
+hugo_installed_spec() {
+  if ! command -v hugo >/dev/null 2>&1; then
+    return 1
+  fi
+  hugo version | awk '{print $2}'
+}
+
+machine_arch() {
+  local machine
+  machine="$(uname -m)"
+  case "$machine" in
+    x86_64 | amd64)
+      printf 'amd64'
+      ;;
+    arm64 | aarch64)
+      printf 'arm64'
+      ;;
+    *)
+      die "unsupported CPU architecture: $machine"
+      ;;
+  esac
+}
+
+install_hugo_linux_tarball() {
+  require_cmd curl
+  require_cmd tar
+  require_cmd install
+
+  local spec="$1"
+  local semver prefix arch url tmp_dir archive
+  semver="$(hugo_semver_from_spec "$spec")"
+  prefix="$(hugo_asset_prefix_from_spec "$spec")"
+  arch="$(machine_arch)"
+  url="https://github.com/gohugoio/hugo/releases/download/v${semver}/${prefix}_${semver}_linux-${arch}.tar.gz"
+
+  tmp_dir="$(mktemp -d "$TMP_DIR/hugo-install.XXXXXX")"
+  archive="$tmp_dir/hugo.tar.gz"
+
+  echo -e "${BLUE}Installing Hugo from:${OFF} ${PURPLE}${url}${OFF}"
+  curl -fsSL "$url" -o "$archive"
+  tar -xzf "$archive" -C "$tmp_dir"
+  [[ -x "$tmp_dir/hugo" ]] || die "downloaded archive does not contain a hugo binary"
+
+  as_root install -m 0755 "$tmp_dir/hugo" /usr/local/bin/hugo
+  rm -rf "$tmp_dir"
+}
+
+install_hugo_macos_pkg() {
+  require_cmd curl
+  require_cmd installer
+
+  local spec="$1"
+  local semver prefix url tmp_dir pkg
+  semver="$(hugo_semver_from_spec "$spec")"
+  prefix="$(hugo_asset_prefix_from_spec "$spec")"
+  url="https://github.com/gohugoio/hugo/releases/download/v${semver}/${prefix}_${semver}_darwin-universal.pkg"
+
+  tmp_dir="$(mktemp -d "$TMP_DIR/hugo-install.XXXXXX")"
+  pkg="$tmp_dir/hugo.pkg"
+
+  echo -e "${BLUE}Installing Hugo from:${OFF} ${PURPLE}${url}${OFF}"
+  curl -fsSL "$url" -o "$pkg"
+  as_root installer -pkg "$pkg" -target /
+  rm -rf "$tmp_dir"
+}
+
+install_hugo_default_linux() {
   if command -v apt-get >/dev/null 2>&1; then
     as_root apt-get update
     as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y hugo
@@ -14,26 +109,69 @@ install_hugo_linux() {
   die "unable to install hugo automatically on linux (apt-get not found)"
 }
 
-install_hugo_macos() {
+install_hugo_default_macos() {
   require_cmd brew
   brew install hugo
 }
 
-if ! command -v hugo >/dev/null 2>&1; then
-  warn "hugo not found; installing..."
+install_hugo_for_ci() {
+  local expected installed
+  expected="$(read_hugo_version_spec)"
+  installed="$(hugo_installed_spec || true)"
+
+  if [[ "$installed" == "$expected" ]]; then
+    echo -e "${GREEN}Hugo version:${OFF} $(hugo version)"
+    return
+  fi
+
+  if [[ -n "$installed" ]]; then
+    warn "hugo version mismatch: found ${installed}, expected ${expected}; installing pinned version"
+  else
+    warn "hugo not found; installing pinned version ${expected}"
+  fi
 
   case "$OSTYPE" in
     linux-gnu*)
-      install_hugo_linux
+      install_hugo_linux_tarball "$expected"
       ;;
     darwin*)
-      install_hugo_macos
+      install_hugo_macos_pkg "$expected"
+      ;;
+    *)
+      die "unsupported OS for CI Hugo install: $OSTYPE"
+      ;;
+  esac
+
+  installed="$(hugo_installed_spec || true)"
+  [[ "$installed" == "$expected" ]] || die "expected Hugo ${expected}, but found ${installed:-<missing>}"
+  echo -e "${GREEN}Hugo version:${OFF} $(hugo version)"
+}
+
+install_hugo_default() {
+  if command -v hugo >/dev/null 2>&1; then
+    echo -e "${GREEN}Hugo version:${OFF} $(hugo version)"
+    return
+  fi
+
+  warn "hugo not found; installing..."
+  case "$OSTYPE" in
+    linux-gnu*)
+      install_hugo_default_linux
+      ;;
+    darwin*)
+      install_hugo_default_macos
       ;;
     *)
       die "unsupported OS for automatic hugo install: $OSTYPE"
       ;;
   esac
-fi
 
-require_cmd hugo
-echo -e "${GREEN}Hugo version:${OFF} $(hugo version)"
+  require_cmd hugo
+  echo -e "${GREEN}Hugo version:${OFF} $(hugo version)"
+}
+
+if [[ "${CI:-}" == "true" ]]; then
+  install_hugo_for_ci
+else
+  install_hugo_default
+fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,39 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+source script/env "$@"
+
+install_hugo_linux() {
+  if command -v apt-get >/dev/null 2>&1; then
+    as_root apt-get update
+    as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y hugo
+    return
+  fi
+
+  die "unable to install hugo automatically on linux (apt-get not found)"
+}
+
+install_hugo_macos() {
+  require_cmd brew
+  brew install hugo
+}
+
+if ! command -v hugo >/dev/null 2>&1; then
+  warn "hugo not found; installing..."
+
+  case "$OSTYPE" in
+    linux-gnu*)
+      install_hugo_linux
+      ;;
+    darwin*)
+      install_hugo_macos
+      ;;
+    *)
+      die "unsupported OS for automatic hugo install: $OSTYPE"
+      ;;
+  esac
+fi
+
+require_cmd hugo
+echo -e "${GREEN}Hugo version:${OFF} $(hugo version)"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,8 +5,9 @@ set -euo pipefail
 source script/env "$@"
 
 HUGO_VERSION_FILE="$DIR/.github/.hugo-version"
+HUGO_VENDOR_BIN_DIR="$DIR/.github/vendor/bin"
 
-read_hugo_version_spec() {
+read_hugo_version() {
   [[ -f "$HUGO_VERSION_FILE" ]] || die "missing Hugo version file: $HUGO_VERSION_FILE"
   local version
   version="$(tr -d '[:space:]' < "$HUGO_VERSION_FILE")"
@@ -14,89 +15,41 @@ read_hugo_version_spec() {
   printf '%s' "$version"
 }
 
-hugo_semver_from_spec() {
-  local spec="$1"
-  spec="${spec#v}"
-  printf '%s' "${spec%%+*}"
+normalize_semver() {
+  local version="$1"
+  version="${version#v}"
+  version="${version%%+*}"
+  version="${version%%-*}"
+  printf '%s' "$version"
 }
 
-hugo_asset_prefix_from_spec() {
-  local spec="$1"
-  if [[ "$spec" == *"+extended+withdeploy"* ]]; then
-    printf 'hugo_extended_withdeploy'
-    return
-  fi
-  if [[ "$spec" == *"+extended"* ]]; then
-    printf 'hugo_extended'
-    return
-  fi
-  printf 'hugo'
-}
-
-hugo_installed_spec() {
+hugo_installed_semver() {
   if ! command -v hugo >/dev/null 2>&1; then
     return 1
   fi
-  hugo version | awk '{print $2}'
+  normalize_semver "$(hugo version | awk '{print $2}')"
 }
 
-machine_arch() {
-  local machine
-  machine="$(uname -m)"
-  case "$machine" in
-    x86_64 | amd64)
-      printf 'amd64'
-      ;;
-    arm64 | aarch64)
-      printf 'arm64'
-      ;;
-    *)
-      die "unsupported CPU architecture: $machine"
-      ;;
-  esac
+install_vendored_hugo_linux() {
+  require_cmd dpkg
+
+  local version="$1"
+  local deb_pkg="$HUGO_VENDOR_BIN_DIR/hugo_extended_${version}_linux-amd64.deb"
+  [[ -f "$deb_pkg" ]] || die "missing vendored Hugo package: $deb_pkg"
+
+  echo -e "${BLUE}Installing vendored Hugo package:${OFF} ${PURPLE}${deb_pkg}${OFF}"
+  as_root dpkg -i "$deb_pkg"
 }
 
-install_hugo_linux_tarball() {
-  require_cmd curl
-  require_cmd tar
-  require_cmd install
-
-  local spec="$1"
-  local semver prefix arch url tmp_dir archive
-  semver="$(hugo_semver_from_spec "$spec")"
-  prefix="$(hugo_asset_prefix_from_spec "$spec")"
-  arch="$(machine_arch)"
-  url="https://github.com/gohugoio/hugo/releases/download/v${semver}/${prefix}_${semver}_linux-${arch}.tar.gz"
-
-  tmp_dir="$(mktemp -d "$TMP_DIR/hugo-install.XXXXXX")"
-  archive="$tmp_dir/hugo.tar.gz"
-
-  echo -e "${BLUE}Installing Hugo from:${OFF} ${PURPLE}${url}${OFF}"
-  curl -fsSL "$url" -o "$archive"
-  tar -xzf "$archive" -C "$tmp_dir"
-  [[ -x "$tmp_dir/hugo" ]] || die "downloaded archive does not contain a hugo binary"
-
-  as_root install -m 0755 "$tmp_dir/hugo" /usr/local/bin/hugo
-  rm -rf "$tmp_dir"
-}
-
-install_hugo_macos_pkg() {
-  require_cmd curl
+install_vendored_hugo_macos() {
   require_cmd installer
 
-  local spec="$1"
-  local semver prefix url tmp_dir pkg
-  semver="$(hugo_semver_from_spec "$spec")"
-  prefix="$(hugo_asset_prefix_from_spec "$spec")"
-  url="https://github.com/gohugoio/hugo/releases/download/v${semver}/${prefix}_${semver}_darwin-universal.pkg"
+  local version="$1"
+  local pkg="$HUGO_VENDOR_BIN_DIR/hugo_extended_${version}_darwin-universal.pkg"
+  [[ -f "$pkg" ]] || die "missing vendored Hugo package: $pkg"
 
-  tmp_dir="$(mktemp -d "$TMP_DIR/hugo-install.XXXXXX")"
-  pkg="$tmp_dir/hugo.pkg"
-
-  echo -e "${BLUE}Installing Hugo from:${OFF} ${PURPLE}${url}${OFF}"
-  curl -fsSL "$url" -o "$pkg"
+  echo -e "${BLUE}Installing vendored Hugo package:${OFF} ${PURPLE}${pkg}${OFF}"
   as_root installer -pkg "$pkg" -target /
-  rm -rf "$tmp_dir"
 }
 
 install_hugo_default_linux() {
@@ -115,35 +68,30 @@ install_hugo_default_macos() {
 }
 
 install_hugo_for_ci() {
-  local expected installed
-  expected="$(read_hugo_version_spec)"
-  installed="$(hugo_installed_spec || true)"
-
-  if [[ "$installed" == "$expected" ]]; then
-    echo -e "${GREEN}Hugo version:${OFF} $(hugo version)"
-    return
-  fi
-
-  if [[ -n "$installed" ]]; then
-    warn "hugo version mismatch: found ${installed}, expected ${expected}; installing pinned version"
+  local expected_version expected_semver installed_semver
+  expected_version="$(read_hugo_version)"
+  expected_semver="$(normalize_semver "$expected_version")"
+  installed_semver="$(hugo_installed_semver || true)"
+  if [[ -n "$installed_semver" ]]; then
+    warn "CI install is pinned; replacing local Hugo ${installed_semver} with vendored ${expected_semver}"
   else
-    warn "hugo not found; installing pinned version ${expected}"
+    warn "hugo not found; installing vendored version ${expected_semver}"
   fi
 
   case "$OSTYPE" in
     linux-gnu*)
-      install_hugo_linux_tarball "$expected"
+      install_vendored_hugo_linux "$expected_version"
       ;;
     darwin*)
-      install_hugo_macos_pkg "$expected"
+      install_vendored_hugo_macos "$expected_version"
       ;;
     *)
       die "unsupported OS for CI Hugo install: $OSTYPE"
       ;;
   esac
 
-  installed="$(hugo_installed_spec || true)"
-  [[ "$installed" == "$expected" ]] || die "expected Hugo ${expected}, but found ${installed:-<missing>}"
+  installed_semver="$(hugo_installed_semver || true)"
+  [[ "$installed_semver" == "$expected_semver" ]] || die "expected Hugo ${expected_semver}, but found ${installed_semver:-<missing>}"
   echo -e "${GREEN}Hugo version:${OFF} $(hugo version)"
 }
 

--- a/script/build
+++ b/script/build
@@ -3,18 +3,32 @@
 set -euo pipefail
 
 source script/env "$@"
+source script/lib/hugo-fixture.sh
 
 require_cmd hugo
+require_cmd mktemp
 
 build_dir="$TMP_DIR/build"
 rm -rf "$build_dir"
 mkdir -p "$build_dir"
 
-echo -e "${BLUE}Building site to:${OFF} ${PURPLE}${build_dir}${OFF}"
+work_dir="$(mktemp -d "$TMP_DIR/hugo-build-fixture.XXXXXX")"
+site_dir="$work_dir/site"
+
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+create_hugo_fixture_site "$site_dir" "$DIR"
+
+echo -e "${BLUE}Building fixture site to:${OFF} ${PURPLE}${build_dir}${OFF}"
 HUGO_ENV=production hugo \
-  --source "$DIR" \
+  --source "$site_dir" \
   --destination "$build_dir" \
   --cleanDestinationDir \
+  --panicOnWarning \
+  --printPathWarnings \
   --minify
 
 echo -e "${GREEN}Build complete${OFF}"

--- a/script/build
+++ b/script/build
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+source script/env "$@"
+
+require_cmd hugo
+
+build_dir="$TMP_DIR/build"
+rm -rf "$build_dir"
+mkdir -p "$build_dir"
+
+echo -e "${BLUE}Building site to:${OFF} ${PURPLE}${build_dir}${OFF}"
+HUGO_ENV=production hugo \
+  --source "$DIR" \
+  --destination "$build_dir" \
+  --cleanDestinationDir \
+  --minify
+
+echo -e "${GREEN}Build complete${OFF}"

--- a/script/env
+++ b/script/env
@@ -1,0 +1,46 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+# COLORS
+export OFF='\033[0m'
+export RED='\033[0;31m'
+export GREEN='\033[0;32m'
+export BLUE='\033[0;34m'
+export PURPLE='\033[0;35m'
+
+# set the working directory to the root of the project
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+export DIR
+
+# The name of the repository is the name of the directory (usually)
+REPO_NAME=$(basename "$DIR")
+export REPO_NAME
+
+TMP_DIR="$DIR/tmp"
+export TMP_DIR
+mkdir -p "$TMP_DIR"
+
+die() {
+  echo -e "${RED}error:${OFF} $*" >&2
+  exit 1
+}
+
+warn() {
+  echo -e "${RED}warning:${OFF} $*" >&2
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required tool: $cmd"
+  fi
+}
+
+as_root() {
+  if command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}

--- a/script/lib/hugo-fixture.sh
+++ b/script/lib/hugo-fixture.sh
@@ -1,0 +1,80 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+create_hugo_fixture_site() {
+  local site_dir="$1"
+  local theme_dir="$2"
+
+  mkdir -p "$site_dir/content/posts" "$site_dir/themes"
+  ln -s "$theme_dir" "$site_dir/themes/dario"
+
+  cat > "$site_dir/hugo.toml" <<'EOF'
+baseURL = "https://example.org/blog/"
+languageCode = "en-us"
+title = "Fixture Site"
+theme = "dario"
+
+[params]
+  description = "Fixture description"
+
+[params.author]
+  name = "Fixture Author"
+EOF
+
+  cat > "$site_dir/content/_index.md" <<'EOF'
++++
+title = "Home *Post*"
+subtitle = "Fixture subtitle"
+description = "Fixture homepage description"
+homePageIsPost = true
+date = 2025-02-24T00:00:00Z
+author = "Fixture Author"
++++
+
+Fixture **content** for the homepage.
+EOF
+
+  cat > "$site_dir/content/posts/first.md" <<'EOF'
++++
+title = "First *Post*"
+description = "Fixture post"
+ogDescription = "A & B"
+date = 2025-02-24T00:00:00Z
++++
+
+Hello from the fixture post.[^1]
+
+## Details
+
+Some text under a heading.
+
+[^1]: Fixture footnote text.
+EOF
+
+  cat > "$site_dir/content/posts/absolute-og.md" <<'EOF'
++++
+title = "Absolute OG"
+description = "Fixture post with absolute OG image"
+ogImage = "https://cdn.example.com/og.png"
+date = 2025-02-25T00:00:00Z
++++
+
+## Absolute Image
+
+This post uses an absolute OG image URL.
+EOF
+
+  cat > "$site_dir/content/posts/no-anchors.md" <<'EOF'
++++
+title = "No Anchors"
+description = "Fixture post with heading anchors disabled"
+disableAnchoredHeadings = true
+date = 2025-02-26T00:00:00Z
++++
+
+## Without Anchor
+
+This post should not render a heading anchor.
+EOF
+}

--- a/script/lint
+++ b/script/lint
@@ -1,0 +1,27 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+source script/env "$@"
+
+require_cmd hugo
+require_cmd bash
+
+for file in "$DIR"/script/*; do
+  [[ -f "$file" ]] || continue
+  bash -n "$file"
+done
+
+if rg -n '@media \((min|max)-inline-size:' "$DIR/assets/css/default.css" >/dev/null; then
+  die "invalid media query feature in assets/css/default.css: use min-width/max-width for viewport queries"
+fi
+
+echo -e "${BLUE}Running Hugo lint checks${OFF}"
+hugo \
+  --source "$DIR" \
+  --renderToMemory \
+  --panicOnWarning \
+  --printPathWarnings \
+  --printI18nWarnings
+
+echo -e "${GREEN}Lint complete${OFF}"

--- a/script/lint
+++ b/script/lint
@@ -3,22 +3,34 @@
 set -euo pipefail
 
 source script/env "$@"
+source script/lib/hugo-fixture.sh
 
 require_cmd hugo
 require_cmd bash
+require_cmd find
+require_cmd mktemp
 
-for file in "$DIR"/script/*; do
-  [[ -f "$file" ]] || continue
+while IFS= read -r -d '' file; do
   bash -n "$file"
-done
+done < <(find "$DIR/script" -type f -print0)
 
-if rg -n '@media \((min|max)-inline-size:' "$DIR/assets/css/default.css" >/dev/null; then
+if grep -nE '@media \((min|max)-inline-size:' "$DIR/assets/css/default.css" >/dev/null; then
   die "invalid media query feature in assets/css/default.css: use min-width/max-width for viewport queries"
 fi
 
+work_dir="$(mktemp -d "$TMP_DIR/hugo-lint-fixture.XXXXXX")"
+site_dir="$work_dir/site"
+
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+create_hugo_fixture_site "$site_dir" "$DIR"
+
 echo -e "${BLUE}Running Hugo lint checks${OFF}"
 hugo \
-  --source "$DIR" \
+  --source "$site_dir" \
   --renderToMemory \
   --panicOnWarning \
   --printPathWarnings \

--- a/script/test
+++ b/script/test
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 source script/env "$@"
+source script/lib/hugo-fixture.sh
 
 require_cmd hugo
 require_cmd grep
@@ -17,45 +18,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$site_dir/content/posts" "$site_dir/themes"
-ln -s "$DIR" "$site_dir/themes/dario"
-
-cat > "$site_dir/hugo.toml" <<'EOF'
-baseURL = "https://example.org/"
-languageCode = "en-us"
-title = "Fixture Site"
-theme = "dario"
-
-[params]
-  description = "Fixture description"
-
-[params.author]
-  name = "Fixture Author"
-EOF
-
-cat > "$site_dir/content/_index.md" <<'EOF'
-+++
-title = "Home *Post*"
-subtitle = "Fixture subtitle"
-description = "Fixture homepage description"
-homePageIsPost = true
-date = 2026-02-24T00:00:00Z
-author = "Fixture Author"
-+++
-
-Fixture **content** for the homepage.
-EOF
-
-cat > "$site_dir/content/posts/first.md" <<'EOF'
-+++
-title = "First *Post*"
-description = "Fixture post"
-ogDescription = "A & B"
-date = 2026-02-24T00:00:00Z
-+++
-
-Hello from the fixture post.
-EOF
+create_hugo_fixture_site "$site_dir" "$DIR"
 
 echo -e "${BLUE}Building fixture site${OFF}"
 hugo \
@@ -66,9 +29,15 @@ hugo \
 
 home_html="$output_dir/index.html"
 post_html="$output_dir/posts/first/index.html"
+absolute_og_html="$output_dir/posts/absolute-og/index.html"
+no_anchor_html="$output_dir/posts/no-anchors/index.html"
+css_file="$(ls "$output_dir"/css/*.css | head -n1)"
 
 [[ -f "$home_html" ]] || die "expected fixture homepage output at $home_html"
 [[ -f "$post_html" ]] || die "expected fixture post output at $post_html"
+[[ -f "$absolute_og_html" ]] || die "expected fixture absolute-og output at $absolute_og_html"
+[[ -f "$no_anchor_html" ]] || die "expected fixture no-anchors output at $no_anchor_html"
+[[ -f "$css_file" ]] || die "expected processed CSS output under $output_dir/css"
 
 if ! grep -Fq "<h1>Home <em>Post</em></h1>" "$home_html"; then
   die "homepage title markdown did not render as expected"
@@ -86,15 +55,71 @@ if ! grep -Fq "<h1>First <em>Post</em></h1>" "$post_html"; then
   die "single post title markdown did not render as expected"
 fi
 
+if ! grep -Fq 'href="#details"' "$post_html"; then
+  die "expected heading anchor link for rendered markdown heading"
+fi
+
+if grep -Fq 'href="#without-anchor"' "$no_anchor_html"; then
+  die "disableAnchoredHeadings should disable heading anchor links"
+fi
+
+if ! grep -q "footnotes" "$post_html"; then
+  die "single post with footnotes should include footnotes script"
+fi
+
+if grep -q "footnotes" "$home_html"; then
+  die "homepage without footnotes should not include footnotes script"
+fi
+
+if ! grep -Fq "fonts/Newsreader.woff2" "$home_html"; then
+  die "expected preload for primary Newsreader font on homepage"
+fi
+
+if grep -Fq "fonts/Newsreader-italic.woff2" "$home_html"; then
+  die "homepage should not preload italic Newsreader font by default"
+fi
+
 if grep -Fq "/default.png" "$home_html"; then
   die "homepage still references missing default OG image fallback"
 fi
 
-if rg -n "A & B" "$output_dir/og"/*.svg >/dev/null; then
+if grep -Fq "https://example.org/blog/blog/" "$post_html"; then
+  die "OG URLs should not duplicate base path segments"
+fi
+
+if ! grep -Fq '<meta property="og:url" content="https://example.org/blog/posts/first/">' "$post_html"; then
+  die "single post should have a canonical og:url based on .Permalink"
+fi
+
+if ! grep -Eq '<meta property="og:image" content="https://example.org/blog/og/og-image-[^"]+\.svg">' "$post_html"; then
+  die "single post should reference generated OG image with a correct absolute URL"
+fi
+
+if ! grep -Fq '<meta property="og:image" content="https://cdn.example.com/og.png">' "$absolute_og_html"; then
+  die "absolute ogImage URL should be passed through without baseURL concatenation"
+fi
+
+if ! grep -Fq "url(../fonts/Newsreader.woff2)" "$css_file"; then
+  die "CSS should reference Newsreader regular font via relative URL"
+fi
+
+if ! grep -Fq "url(../fonts/Newsreader-italic.woff2)" "$css_file"; then
+  die "CSS should reference Newsreader italic font via relative URL"
+fi
+
+if grep -Fq "url(/fonts/" "$css_file"; then
+  die "CSS should not use root-absolute font URLs"
+fi
+
+if ! grep -Fq "../fonts/Newsreader.woff2" "$output_dir"/og/*.svg; then
+  die "generated OG SVG should use a relative font URL"
+fi
+
+if grep -q "A & B" "$output_dir"/og/*.svg; then
   die "OG SVG contains unescaped ampersand in description"
 fi
 
-if ! rg -n "A &amp; B" "$output_dir/og"/*.svg >/dev/null; then
+if ! grep -q "A &amp; B" "$output_dir"/og/*.svg; then
   die "OG SVG is missing escaped description content"
 fi
 

--- a/script/test
+++ b/script/test
@@ -1,0 +1,101 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+source script/env "$@"
+
+require_cmd hugo
+require_cmd grep
+require_cmd mktemp
+
+work_dir="$(mktemp -d "$TMP_DIR/hugo-fixture.XXXXXX")"
+site_dir="$work_dir/site"
+output_dir="$work_dir/public"
+
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$site_dir/content/posts" "$site_dir/themes"
+ln -s "$DIR" "$site_dir/themes/dario"
+
+cat > "$site_dir/hugo.toml" <<'EOF'
+baseURL = "https://example.org/"
+languageCode = "en-us"
+title = "Fixture Site"
+theme = "dario"
+
+[params]
+  description = "Fixture description"
+
+[params.author]
+  name = "Fixture Author"
+EOF
+
+cat > "$site_dir/content/_index.md" <<'EOF'
++++
+title = "Home *Post*"
+subtitle = "Fixture subtitle"
+description = "Fixture homepage description"
+homePageIsPost = true
+date = 2026-02-24T00:00:00Z
+author = "Fixture Author"
++++
+
+Fixture **content** for the homepage.
+EOF
+
+cat > "$site_dir/content/posts/first.md" <<'EOF'
++++
+title = "First *Post*"
+description = "Fixture post"
+ogDescription = "A & B"
+date = 2026-02-24T00:00:00Z
++++
+
+Hello from the fixture post.
+EOF
+
+echo -e "${BLUE}Building fixture site${OFF}"
+hugo \
+  --source "$site_dir" \
+  --destination "$output_dir" \
+  --panicOnWarning \
+  --printPathWarnings
+
+home_html="$output_dir/index.html"
+post_html="$output_dir/posts/first/index.html"
+
+[[ -f "$home_html" ]] || die "expected fixture homepage output at $home_html"
+[[ -f "$post_html" ]] || die "expected fixture post output at $post_html"
+
+if ! grep -Fq "<h1>Home <em>Post</em></h1>" "$home_html"; then
+  die "homepage title markdown did not render as expected"
+fi
+
+if grep -Fq "First *Post*" "$home_html"; then
+  die "homepage post list title was not plainified as expected"
+fi
+
+if ! grep -Fq "First Post" "$home_html"; then
+  die "homepage post list title text missing expected plainified value"
+fi
+
+if ! grep -Fq "<h1>First <em>Post</em></h1>" "$post_html"; then
+  die "single post title markdown did not render as expected"
+fi
+
+if grep -Fq "/default.png" "$home_html"; then
+  die "homepage still references missing default OG image fallback"
+fi
+
+if rg -n "A & B" "$output_dir/og"/*.svg >/dev/null; then
+  die "OG SVG contains unescaped ampersand in description"
+fi
+
+if ! rg -n "A &amp; B" "$output_dir/og"/*.svg >/dev/null; then
+  die "OG SVG is missing escaped description content"
+fi
+
+echo -e "${GREEN}Fixture tests passed${OFF}"


### PR DESCRIPTION
# 🧱 Hugo CI + Theme Hardening

## About

This pull request makes CI reproducible for this Hugo theme and fixes template behavior that was not aligned with Hugo best practices. It also hardens rendering for subpath deployments and improves output correctness for social metadata and heading anchors.

## Reason

The branch had failing checks on macOS/Linux due to environment assumptions (`rg` availability, repo-root Hugo source usage, and fragile exact Hugo version string matching), and there were template URL patterns that could produce invalid Open Graph output under non-root `baseURL` setups.

- Pin Hugo to `0.156.0` via `.github/.hugo-version`.
- Vendor Hugo installers under `.github/vendor/bin/` and install those in CI only.
- Build/lint/test against a generated fixture site instead of repository root so theme CI does not depend on a local Hugo config.
- Replace brittle meta URL concatenation and regex heading rewriting with Hugo-native patterns.

## Details

Added and integrated script-driven CI hardening across `script/bootstrap`, `script/build`, `script/lint`, and `script/test`, including a shared fixture generator at `script/lib/hugo-fixture.sh`, portable `grep/find` checks, and expanded fixture assertions for OG/meta/font/anchor behavior. CI now installs vendored Hugo binaries from `.github/vendor/bin` (`.deb` on Linux and `.pkg` on macOS) using the version in `.github/.hugo-version`, while local bootstrap remains local-only and unchanged in intent. Templates now use `partialCached`, OG tags use correct permalink/absolute URL handling, heading anchors are implemented via `layouts/_markup/render-heading.html`, and obsolete regex anchor injection was removed.

## Design

The design keeps CI simple and deterministic by concentrating logic in scripts and using checked-in Hugo installers so runners do not depend on external package feeds or release API behavior. Fixture-based output checks provide deterministic validation for a theme repository where the root is not itself a runnable Hugo site.
