### PR TITLE
Prevent OG SVG template execution

### DIFF
--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -36,7 +36,8 @@
     </svg>
     ` ($title | htmlEscape) ($description | htmlEscape) | safeHTML }}
 
-{{- $generatedSVG := resources.FromString $uniqueName $svg | resources.ExecuteAsTemplate $uniqueName . -}}
+{{- /* Do not execute the generated SVG as a template: title/description can be content-derived. */ -}}
+{{- $generatedSVG := resources.FromString $uniqueName $svg -}}
 
 {{- /* Determine which image URL to use */ -}}
 {{- $ogImageURL := $generatedSVG.Permalink }}

--- a/script/lib/hugo-fixture.sh
+++ b/script/lib/hugo-fixture.sh
@@ -77,4 +77,14 @@ date = 2025-02-26T00:00:00Z
 
 This post should not render a heading anchor.
 EOF
+
+  cat > "$site_dir/content/posts/template-literal-og.md" <<'EOF'
++++
+title = "{{ .Site.Title }}"
+description = "{{ now.Year }}"
+date = 2025-02-27T00:00:00Z
++++
+
+This post verifies that Open Graph SVG generation does not execute template actions from content.
+EOF
 }

--- a/script/test
+++ b/script/test
@@ -31,12 +31,14 @@ home_html="$output_dir/index.html"
 post_html="$output_dir/posts/first/index.html"
 absolute_og_html="$output_dir/posts/absolute-og/index.html"
 no_anchor_html="$output_dir/posts/no-anchors/index.html"
+template_literal_og_html="$output_dir/posts/template-literal-og/index.html"
 css_file="$(ls "$output_dir"/css/*.css | head -n1)"
 
 [[ -f "$home_html" ]] || die "expected fixture homepage output at $home_html"
 [[ -f "$post_html" ]] || die "expected fixture post output at $post_html"
 [[ -f "$absolute_og_html" ]] || die "expected fixture absolute-og output at $absolute_og_html"
 [[ -f "$no_anchor_html" ]] || die "expected fixture no-anchors output at $no_anchor_html"
+[[ -f "$template_literal_og_html" ]] || die "expected template-literal-og output at $template_literal_og_html"
 [[ -f "$css_file" ]] || die "expected processed CSS output under $output_dir/css"
 
 if ! grep -Fq "<h1>Home <em>Post</em></h1>" "$home_html"; then
@@ -97,6 +99,22 @@ fi
 
 if ! grep -Fq '<meta property="og:image" content="https://cdn.example.com/og.png">' "$absolute_og_html"; then
   die "absolute ogImage URL should be passed through without baseURL concatenation"
+fi
+
+if ! grep -Fq '<meta property="og:title" content="{{ .Site.Title }}">' "$template_literal_og_html"; then
+  die "template-like OG title should remain literal in HTML meta tags"
+fi
+
+if ! grep -Fq '<meta property="og:description" content="{{ now.Year }}">' "$template_literal_og_html"; then
+  die "template-like OG description should remain literal in HTML meta tags"
+fi
+
+if ! grep -Fq "{{ .Site.Title }}" "$output_dir"/og/*.svg; then
+  die "generated OG SVG should preserve literal template delimiters in the title"
+fi
+
+if ! grep -Fq "{{ now.Year }}" "$output_dir"/og/*.svg; then
+  die "generated OG SVG should preserve literal template delimiters in the description"
 fi
 
 if ! grep -Fq "url(../fonts/Newsreader.woff2)" "$css_file"; then


### PR DESCRIPTION
Stop running generated Open Graph SVG resources through `resources.ExecuteAsTemplate`, which allowed content-derived `title` and `description` fields to be interpreted as Hugo template actions at build time.

Add a fixture post and `script/test` coverage to verify template-like front matter remains literal in both the HTML meta tags and the generated OG SVG.
