### PR TITLE
Improve code rendering and verify vendored Hugo installers

### DIFF
--- a/.github/vendor/bin/SHA256SUMS
+++ b/.github/vendor/bin/SHA256SUMS
@@ -1,0 +1,2 @@
+42d37400f8fdd030eb3d6f26e2eb47496f690ef540c2a5d650f0af4f64bab985  hugo_extended_0.156.0_darwin-universal.pkg
+28111b85cd44c258c0cc59da00ae2210c12a55749b7fd77e7421ab963b7adcda  hugo_extended_0.156.0_linux-amd64.deb

--- a/README.md
+++ b/README.md
@@ -89,22 +89,25 @@ Add the following to your `config.toml`:
 [module]
   [[module.imports]]
     path = "github.com/GrantBirki/dario"
-    version = "main"
 ```
 
 Note that there's no `theme = "dario"` in this case. If you already have this in your `config.toml`, please remove it.
 
-Fetch the theme:
+Review the Dario commit you intend to consume, then fetch it by its full 40-character revision. This example points to a known commit; replace it only after reviewing a newer revision:
 
 ```bash
-hugo mod get github.com/GrantBirki/dario@main
+DARIO_SHA="b0fa756c824bc7b9e4d64b75711b8742e44c7dc0"
+hugo mod get "github.com/GrantBirki/dario@${DARIO_SHA}"
 hugo mod tidy
 ```
 
-To upgrade to the latest version of the theme:
+Hugo records the commit as an immutable pseudo-version in `go.mod`, while `go.sum` authenticates the downloaded module content. The import in `config.toml` intentionally has no mutable version selector because `go.mod` is the dependency authority.
+
+To upgrade the theme, review a newer Dario commit and run the same targeted update with its full revision:
 
 ```bash
-hugo mod get -u github.com/GrantBirki/dario@main
+DARIO_SHA="REPLACE_WITH_A_REVIEWED_40_CHARACTER_COMMIT_SHA"
+hugo mod get "github.com/GrantBirki/dario@${DARIO_SHA}"
 hugo mod tidy
 ```
 

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -55,7 +55,8 @@ header h1 a {
   --subscribe-button-text: #141413;
   --invert-percentage: 100%;
   --code-bg: rgb(55, 56, 62);
-  --hljs-bg: rgb(46, 46, 51);
+  --code-block-bg: #0d1117;
+  --code-block-border: #30363d;
   --muted-text-color: #b3b3b3;
 }
 
@@ -77,7 +78,8 @@ header h1 a {
   --subscribe-button-text: #f0efea;
   --invert-percentage: 0%;
   --code-bg: rgb(223, 223, 223);
-  --hljs-bg: rgb(28, 29, 33);
+  --code-block-bg: #f7f7f7;
+  --code-block-border: #d0d7de;
   --muted-text-color: #666666;
 }
 
@@ -100,7 +102,8 @@ header h1 a {
     --subscribe-button-text: #141413;
     --invert-percentage: 100%;
     --code-bg: rgb(55, 56, 62);
-    --hljs-bg: rgb(46, 46, 51);
+    --code-block-bg: #0d1117;
+    --code-block-border: #30363d;
     --muted-text-color: #b3b3b3;
   }
 }
@@ -124,7 +127,8 @@ header h1 a {
     --subscribe-button-text: #f0efea;
     --invert-percentage: 0%;
     --code-bg: rgb(223, 223, 223);
-    --hljs-bg: rgb(28, 29, 33);
+    --code-block-bg: #f7f7f7;
+    --code-block-border: #d0d7de;
     --muted-text-color: #666666;
   }
 }
@@ -176,15 +180,36 @@ code {
   font-family: menlo, Consolas, ui-monospace, monospace;
 }
 
-pre code {
-  display: block;
-  margin-block: auto;
+pre {
+  box-sizing: border-box;
+  margin-block: 1.25em;
   margin-inline: 0;
-  color: rgb(213, 213, 214);
-  background: var(--hljs-bg) !important;
+  padding: 1rem;
+  background: var(--code-block-bg);
+  border: 1px solid var(--code-block-border);
   border-radius: var(--radius);
   overflow-x: auto;
-  word-break: break-all;
+  white-space: pre;
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+pre:focus-visible {
+  outline: 3px solid var(--focus-color);
+  outline-offset: 2px;
+}
+
+pre code {
+  display: block;
+  margin: 0;
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  border-radius: 0;
+  overflow: visible;
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
 }
 
 h1:hover .anchor,
@@ -192,17 +217,25 @@ h2:hover .anchor,
 h3:hover .anchor,
 h4:hover .anchor,
 h5:hover .anchor,
-h6:hover .anchor {
-  display: inline-flex;
-  color: var(--text-color);
-  margin-inline-start: 8px;
-  font-weight: 500;
-  user-select: none;
+h6:hover .anchor,
+.anchor:hover {
   opacity: 0.5;
 }
 
 .anchor {
-  display: none;
+  display: inline-flex;
+  color: var(--text-color);
+  margin-inline-start: 8px;
+  font-weight: 500;
+  text-decoration: none;
+  user-select: none;
+  opacity: 0;
+}
+
+.anchor:focus-visible {
+  opacity: 1;
+  outline: 3px solid var(--focus-color);
+  outline-offset: 2px;
 }
 
 a {

--- a/assets/css/syntax.css
+++ b/assets/css/syntax.css
@@ -1,0 +1,313 @@
+/* Generated with Hugo 0.156.0 and scoped to Dario's color modes:
+ * hugo gen chromastyles --style github
+ * hugo gen chromastyles --style github-dark
+ */
+
+
+/* Background */ .dark-mode-off:root .bg { background-color:#f7f7f7; }
+/* PreWrapper */ .dark-mode-off:root .chroma { background-color:#f7f7f7;-webkit-text-size-adjust:none; }
+/* Error */ .dark-mode-off:root .chroma .err { color:#f6f8fa;background-color:#82071e }
+/* LineLink */ .dark-mode-off:root .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+/* LineTableTD */ .dark-mode-off:root .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+/* LineTable */ .dark-mode-off:root .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+/* LineHighlight */ .dark-mode-off:root .chroma .hl { background-color:#dedede }
+/* LineNumbersTable */ .dark-mode-off:root .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f }
+/* LineNumbers */ .dark-mode-off:root .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f }
+/* Line */ .dark-mode-off:root .chroma .line { display:flex; }
+/* Keyword */ .dark-mode-off:root .chroma .k { color:#cf222e }
+/* KeywordConstant */ .dark-mode-off:root .chroma .kc { color:#cf222e }
+/* KeywordDeclaration */ .dark-mode-off:root .chroma .kd { color:#cf222e }
+/* KeywordNamespace */ .dark-mode-off:root .chroma .kn { color:#cf222e }
+/* KeywordPseudo */ .dark-mode-off:root .chroma .kp { color:#cf222e }
+/* KeywordReserved */ .dark-mode-off:root .chroma .kr { color:#cf222e }
+/* KeywordType */ .dark-mode-off:root .chroma .kt { color:#cf222e }
+/* NameAttribute */ .dark-mode-off:root .chroma .na { color:#1f2328 }
+/* NameClass */ .dark-mode-off:root .chroma .nc { color:#1f2328 }
+/* NameConstant */ .dark-mode-off:root .chroma .no { color:#0550ae }
+/* NameDecorator */ .dark-mode-off:root .chroma .nd { color:#0550ae }
+/* NameEntity */ .dark-mode-off:root .chroma .ni { color:#6639ba }
+/* NameLabel */ .dark-mode-off:root .chroma .nl { color:#900;font-weight:bold }
+/* NameNamespace */ .dark-mode-off:root .chroma .nn { color:#24292e }
+/* NameOther */ .dark-mode-off:root .chroma .nx { color:#1f2328 }
+/* NameTag */ .dark-mode-off:root .chroma .nt { color:#0550ae }
+/* NameBuiltin */ .dark-mode-off:root .chroma .nb { color:#6639ba }
+/* NameBuiltinPseudo */ .dark-mode-off:root .chroma .bp { color:#6a737d }
+/* NameVariable */ .dark-mode-off:root .chroma .nv { color:#953800 }
+/* NameVariableClass */ .dark-mode-off:root .chroma .vc { color:#953800 }
+/* NameVariableGlobal */ .dark-mode-off:root .chroma .vg { color:#953800 }
+/* NameVariableInstance */ .dark-mode-off:root .chroma .vi { color:#953800 }
+/* NameVariableMagic */ .dark-mode-off:root .chroma .vm { color:#953800 }
+/* NameFunction */ .dark-mode-off:root .chroma .nf { color:#6639ba }
+/* NameFunctionMagic */ .dark-mode-off:root .chroma .fm { color:#6639ba }
+/* LiteralString */ .dark-mode-off:root .chroma .s { color:#0a3069 }
+/* LiteralStringAffix */ .dark-mode-off:root .chroma .sa { color:#0a3069 }
+/* LiteralStringBacktick */ .dark-mode-off:root .chroma .sb { color:#0a3069 }
+/* LiteralStringChar */ .dark-mode-off:root .chroma .sc { color:#0a3069 }
+/* LiteralStringDelimiter */ .dark-mode-off:root .chroma .dl { color:#0a3069 }
+/* LiteralStringDoc */ .dark-mode-off:root .chroma .sd { color:#0a3069 }
+/* LiteralStringDouble */ .dark-mode-off:root .chroma .s2 { color:#0a3069 }
+/* LiteralStringEscape */ .dark-mode-off:root .chroma .se { color:#0a3069 }
+/* LiteralStringHeredoc */ .dark-mode-off:root .chroma .sh { color:#0a3069 }
+/* LiteralStringInterpol */ .dark-mode-off:root .chroma .si { color:#0a3069 }
+/* LiteralStringOther */ .dark-mode-off:root .chroma .sx { color:#0a3069 }
+/* LiteralStringRegex */ .dark-mode-off:root .chroma .sr { color:#0a3069 }
+/* LiteralStringSingle */ .dark-mode-off:root .chroma .s1 { color:#0a3069 }
+/* LiteralStringSymbol */ .dark-mode-off:root .chroma .ss { color:#032f62 }
+/* LiteralNumber */ .dark-mode-off:root .chroma .m { color:#0550ae }
+/* LiteralNumberBin */ .dark-mode-off:root .chroma .mb { color:#0550ae }
+/* LiteralNumberFloat */ .dark-mode-off:root .chroma .mf { color:#0550ae }
+/* LiteralNumberHex */ .dark-mode-off:root .chroma .mh { color:#0550ae }
+/* LiteralNumberInteger */ .dark-mode-off:root .chroma .mi { color:#0550ae }
+/* LiteralNumberIntegerLong */ .dark-mode-off:root .chroma .il { color:#0550ae }
+/* LiteralNumberOct */ .dark-mode-off:root .chroma .mo { color:#0550ae }
+/* Operator */ .dark-mode-off:root .chroma .o { color:#0550ae }
+/* OperatorWord */ .dark-mode-off:root .chroma .ow { color:#0550ae }
+/* Punctuation */ .dark-mode-off:root .chroma .p { color:#1f2328 }
+/* Comment */ .dark-mode-off:root .chroma .c { color:#57606a }
+/* CommentHashbang */ .dark-mode-off:root .chroma .ch { color:#57606a }
+/* CommentMultiline */ .dark-mode-off:root .chroma .cm { color:#57606a }
+/* CommentSingle */ .dark-mode-off:root .chroma .c1 { color:#57606a }
+/* CommentSpecial */ .dark-mode-off:root .chroma .cs { color:#57606a }
+/* CommentPreproc */ .dark-mode-off:root .chroma .cp { color:#57606a }
+/* CommentPreprocFile */ .dark-mode-off:root .chroma .cpf { color:#57606a }
+/* GenericDeleted */ .dark-mode-off:root .chroma .gd { color:#82071e;background-color:#ffebe9 }
+/* GenericEmph */ .dark-mode-off:root .chroma .ge { color:#1f2328 }
+/* GenericInserted */ .dark-mode-off:root .chroma .gi { color:#116329;background-color:#dafbe1 }
+/* GenericOutput */ .dark-mode-off:root .chroma .go { color:#1f2328 }
+/* GenericUnderline */ .dark-mode-off:root .chroma .gl { text-decoration:underline }
+/* TextWhitespace */ .dark-mode-off:root .chroma .w { color:#fff }
+
+
+/* Background */ .dark-mode-on:root .bg { color:#e6edf3;background-color:#0d1117; }
+/* PreWrapper */ .dark-mode-on:root .chroma { color:#e6edf3;background-color:#0d1117;-webkit-text-size-adjust:none; }
+/* Error */ .dark-mode-on:root .chroma .err { color:#f85149 }
+/* LineLink */ .dark-mode-on:root .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+/* LineTableTD */ .dark-mode-on:root .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+/* LineTable */ .dark-mode-on:root .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+/* LineHighlight */ .dark-mode-on:root .chroma .hl { background-color:#6e7681 }
+/* LineNumbersTable */ .dark-mode-on:root .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#737679 }
+/* LineNumbers */ .dark-mode-on:root .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#6e7681 }
+/* Line */ .dark-mode-on:root .chroma .line { display:flex; }
+/* Keyword */ .dark-mode-on:root .chroma .k { color:#ff7b72 }
+/* KeywordConstant */ .dark-mode-on:root .chroma .kc { color:#79c0ff }
+/* KeywordDeclaration */ .dark-mode-on:root .chroma .kd { color:#ff7b72 }
+/* KeywordNamespace */ .dark-mode-on:root .chroma .kn { color:#ff7b72 }
+/* KeywordPseudo */ .dark-mode-on:root .chroma .kp { color:#79c0ff }
+/* KeywordReserved */ .dark-mode-on:root .chroma .kr { color:#ff7b72 }
+/* KeywordType */ .dark-mode-on:root .chroma .kt { color:#ff7b72 }
+/* NameClass */ .dark-mode-on:root .chroma .nc { color:#f0883e;font-weight:bold }
+/* NameConstant */ .dark-mode-on:root .chroma .no { color:#79c0ff;font-weight:bold }
+/* NameDecorator */ .dark-mode-on:root .chroma .nd { color:#d2a8ff;font-weight:bold }
+/* NameEntity */ .dark-mode-on:root .chroma .ni { color:#ffa657 }
+/* NameException */ .dark-mode-on:root .chroma .ne { color:#f0883e;font-weight:bold }
+/* NameLabel */ .dark-mode-on:root .chroma .nl { color:#79c0ff;font-weight:bold }
+/* NameNamespace */ .dark-mode-on:root .chroma .nn { color:#ff7b72 }
+/* NameProperty */ .dark-mode-on:root .chroma .py { color:#79c0ff }
+/* NameTag */ .dark-mode-on:root .chroma .nt { color:#7ee787 }
+/* NameVariable */ .dark-mode-on:root .chroma .nv { color:#79c0ff }
+/* NameVariableClass */ .dark-mode-on:root .chroma .vc { color:#79c0ff }
+/* NameVariableGlobal */ .dark-mode-on:root .chroma .vg { color:#79c0ff }
+/* NameVariableInstance */ .dark-mode-on:root .chroma .vi { color:#79c0ff }
+/* NameVariableMagic */ .dark-mode-on:root .chroma .vm { color:#79c0ff }
+/* NameFunction */ .dark-mode-on:root .chroma .nf { color:#d2a8ff;font-weight:bold }
+/* NameFunctionMagic */ .dark-mode-on:root .chroma .fm { color:#d2a8ff;font-weight:bold }
+/* Literal */ .dark-mode-on:root .chroma .l { color:#a5d6ff }
+/* LiteralDate */ .dark-mode-on:root .chroma .ld { color:#79c0ff }
+/* LiteralString */ .dark-mode-on:root .chroma .s { color:#a5d6ff }
+/* LiteralStringAffix */ .dark-mode-on:root .chroma .sa { color:#79c0ff }
+/* LiteralStringBacktick */ .dark-mode-on:root .chroma .sb { color:#a5d6ff }
+/* LiteralStringChar */ .dark-mode-on:root .chroma .sc { color:#a5d6ff }
+/* LiteralStringDelimiter */ .dark-mode-on:root .chroma .dl { color:#79c0ff }
+/* LiteralStringDoc */ .dark-mode-on:root .chroma .sd { color:#a5d6ff }
+/* LiteralStringDouble */ .dark-mode-on:root .chroma .s2 { color:#a5d6ff }
+/* LiteralStringEscape */ .dark-mode-on:root .chroma .se { color:#79c0ff }
+/* LiteralStringHeredoc */ .dark-mode-on:root .chroma .sh { color:#79c0ff }
+/* LiteralStringInterpol */ .dark-mode-on:root .chroma .si { color:#a5d6ff }
+/* LiteralStringOther */ .dark-mode-on:root .chroma .sx { color:#a5d6ff }
+/* LiteralStringRegex */ .dark-mode-on:root .chroma .sr { color:#79c0ff }
+/* LiteralStringSingle */ .dark-mode-on:root .chroma .s1 { color:#a5d6ff }
+/* LiteralStringSymbol */ .dark-mode-on:root .chroma .ss { color:#a5d6ff }
+/* LiteralNumber */ .dark-mode-on:root .chroma .m { color:#a5d6ff }
+/* LiteralNumberBin */ .dark-mode-on:root .chroma .mb { color:#a5d6ff }
+/* LiteralNumberFloat */ .dark-mode-on:root .chroma .mf { color:#a5d6ff }
+/* LiteralNumberHex */ .dark-mode-on:root .chroma .mh { color:#a5d6ff }
+/* LiteralNumberInteger */ .dark-mode-on:root .chroma .mi { color:#a5d6ff }
+/* LiteralNumberIntegerLong */ .dark-mode-on:root .chroma .il { color:#a5d6ff }
+/* LiteralNumberOct */ .dark-mode-on:root .chroma .mo { color:#a5d6ff }
+/* Operator */ .dark-mode-on:root .chroma .o { color:#ff7b72;font-weight:bold }
+/* OperatorWord */ .dark-mode-on:root .chroma .ow { color:#ff7b72;font-weight:bold }
+/* Comment */ .dark-mode-on:root .chroma .c { color:#8b949e;font-style:italic }
+/* CommentHashbang */ .dark-mode-on:root .chroma .ch { color:#8b949e;font-style:italic }
+/* CommentMultiline */ .dark-mode-on:root .chroma .cm { color:#8b949e;font-style:italic }
+/* CommentSingle */ .dark-mode-on:root .chroma .c1 { color:#8b949e;font-style:italic }
+/* CommentSpecial */ .dark-mode-on:root .chroma .cs { color:#8b949e;font-weight:bold;font-style:italic }
+/* CommentPreproc */ .dark-mode-on:root .chroma .cp { color:#8b949e;font-weight:bold;font-style:italic }
+/* CommentPreprocFile */ .dark-mode-on:root .chroma .cpf { color:#8b949e;font-weight:bold;font-style:italic }
+/* GenericDeleted */ .dark-mode-on:root .chroma .gd { color:#ffa198;background-color:#490202 }
+/* GenericEmph */ .dark-mode-on:root .chroma .ge { font-style:italic }
+/* GenericError */ .dark-mode-on:root .chroma .gr { color:#ffa198 }
+/* GenericHeading */ .dark-mode-on:root .chroma .gh { color:#79c0ff;font-weight:bold }
+/* GenericInserted */ .dark-mode-on:root .chroma .gi { color:#56d364;background-color:#0f5323 }
+/* GenericOutput */ .dark-mode-on:root .chroma .go { color:#8b949e }
+/* GenericPrompt */ .dark-mode-on:root .chroma .gp { color:#8b949e }
+/* GenericStrong */ .dark-mode-on:root .chroma .gs { font-weight:bold }
+/* GenericSubheading */ .dark-mode-on:root .chroma .gu { color:#79c0ff }
+/* GenericTraceback */ .dark-mode-on:root .chroma .gt { color:#ff7b72 }
+/* GenericUnderline */ .dark-mode-on:root .chroma .gl { text-decoration:underline }
+/* TextWhitespace */ .dark-mode-on:root .chroma .w { color:#6e7681 }
+
+@media (prefers-color-scheme: light) {
+
+  /* Background */ :root:not(.dark-mode-on):not(.dark-mode-off) .bg { background-color:#f7f7f7; }
+  /* PreWrapper */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma { background-color:#f7f7f7;-webkit-text-size-adjust:none; }
+  /* Error */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .err { color:#f6f8fa;background-color:#82071e }
+  /* LineLink */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+  /* LineTableTD */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+  /* LineTable */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+  /* LineHighlight */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .hl { background-color:#dedede }
+  /* LineNumbersTable */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f }
+  /* LineNumbers */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f }
+  /* Line */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .line { display:flex; }
+  /* Keyword */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .k { color:#cf222e }
+  /* KeywordConstant */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kc { color:#cf222e }
+  /* KeywordDeclaration */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kd { color:#cf222e }
+  /* KeywordNamespace */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kn { color:#cf222e }
+  /* KeywordPseudo */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kp { color:#cf222e }
+  /* KeywordReserved */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kr { color:#cf222e }
+  /* KeywordType */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kt { color:#cf222e }
+  /* NameAttribute */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .na { color:#1f2328 }
+  /* NameClass */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nc { color:#1f2328 }
+  /* NameConstant */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .no { color:#0550ae }
+  /* NameDecorator */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nd { color:#0550ae }
+  /* NameEntity */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ni { color:#6639ba }
+  /* NameLabel */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nl { color:#900;font-weight:bold }
+  /* NameNamespace */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nn { color:#24292e }
+  /* NameOther */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nx { color:#1f2328 }
+  /* NameTag */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nt { color:#0550ae }
+  /* NameBuiltin */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nb { color:#6639ba }
+  /* NameBuiltinPseudo */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .bp { color:#6a737d }
+  /* NameVariable */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nv { color:#953800 }
+  /* NameVariableClass */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .vc { color:#953800 }
+  /* NameVariableGlobal */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .vg { color:#953800 }
+  /* NameVariableInstance */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .vi { color:#953800 }
+  /* NameVariableMagic */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .vm { color:#953800 }
+  /* NameFunction */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nf { color:#6639ba }
+  /* NameFunctionMagic */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .fm { color:#6639ba }
+  /* LiteralString */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .s { color:#0a3069 }
+  /* LiteralStringAffix */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sa { color:#0a3069 }
+  /* LiteralStringBacktick */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sb { color:#0a3069 }
+  /* LiteralStringChar */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sc { color:#0a3069 }
+  /* LiteralStringDelimiter */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .dl { color:#0a3069 }
+  /* LiteralStringDoc */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sd { color:#0a3069 }
+  /* LiteralStringDouble */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .s2 { color:#0a3069 }
+  /* LiteralStringEscape */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .se { color:#0a3069 }
+  /* LiteralStringHeredoc */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sh { color:#0a3069 }
+  /* LiteralStringInterpol */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .si { color:#0a3069 }
+  /* LiteralStringOther */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sx { color:#0a3069 }
+  /* LiteralStringRegex */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sr { color:#0a3069 }
+  /* LiteralStringSingle */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .s1 { color:#0a3069 }
+  /* LiteralStringSymbol */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ss { color:#032f62 }
+  /* LiteralNumber */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .m { color:#0550ae }
+  /* LiteralNumberBin */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .mb { color:#0550ae }
+  /* LiteralNumberFloat */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .mf { color:#0550ae }
+  /* LiteralNumberHex */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .mh { color:#0550ae }
+  /* LiteralNumberInteger */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .mi { color:#0550ae }
+  /* LiteralNumberIntegerLong */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .il { color:#0550ae }
+  /* LiteralNumberOct */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .mo { color:#0550ae }
+  /* Operator */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .o { color:#0550ae }
+  /* OperatorWord */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ow { color:#0550ae }
+  /* Punctuation */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .p { color:#1f2328 }
+  /* Comment */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .c { color:#57606a }
+  /* CommentHashbang */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ch { color:#57606a }
+  /* CommentMultiline */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .cm { color:#57606a }
+  /* CommentSingle */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .c1 { color:#57606a }
+  /* CommentSpecial */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .cs { color:#57606a }
+  /* CommentPreproc */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .cp { color:#57606a }
+  /* CommentPreprocFile */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .cpf { color:#57606a }
+  /* GenericDeleted */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gd { color:#82071e;background-color:#ffebe9 }
+  /* GenericEmph */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ge { color:#1f2328 }
+  /* GenericInserted */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gi { color:#116329;background-color:#dafbe1 }
+  /* GenericOutput */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .go { color:#1f2328 }
+  /* GenericUnderline */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gl { text-decoration:underline }
+  /* TextWhitespace */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .w { color:#fff }
+}
+@media (prefers-color-scheme: dark) {
+
+  /* Background */ :root:not(.dark-mode-on):not(.dark-mode-off) .bg { color:#e6edf3;background-color:#0d1117; }
+  /* PreWrapper */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma { color:#e6edf3;background-color:#0d1117;-webkit-text-size-adjust:none; }
+  /* Error */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .err { color:#f85149 }
+  /* LineLink */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+  /* LineTableTD */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+  /* LineTable */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+  /* LineHighlight */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .hl { background-color:#6e7681 }
+  /* LineNumbersTable */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#737679 }
+  /* LineNumbers */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#6e7681 }
+  /* Line */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .line { display:flex; }
+  /* Keyword */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .k { color:#ff7b72 }
+  /* KeywordConstant */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kc { color:#79c0ff }
+  /* KeywordDeclaration */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kd { color:#ff7b72 }
+  /* KeywordNamespace */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kn { color:#ff7b72 }
+  /* KeywordPseudo */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kp { color:#79c0ff }
+  /* KeywordReserved */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kr { color:#ff7b72 }
+  /* KeywordType */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .kt { color:#ff7b72 }
+  /* NameClass */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nc { color:#f0883e;font-weight:bold }
+  /* NameConstant */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .no { color:#79c0ff;font-weight:bold }
+  /* NameDecorator */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nd { color:#d2a8ff;font-weight:bold }
+  /* NameEntity */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ni { color:#ffa657 }
+  /* NameException */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ne { color:#f0883e;font-weight:bold }
+  /* NameLabel */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nl { color:#79c0ff;font-weight:bold }
+  /* NameNamespace */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nn { color:#ff7b72 }
+  /* NameProperty */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .py { color:#79c0ff }
+  /* NameTag */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nt { color:#7ee787 }
+  /* NameVariable */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nv { color:#79c0ff }
+  /* NameVariableClass */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .vc { color:#79c0ff }
+  /* NameVariableGlobal */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .vg { color:#79c0ff }
+  /* NameVariableInstance */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .vi { color:#79c0ff }
+  /* NameVariableMagic */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .vm { color:#79c0ff }
+  /* NameFunction */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .nf { color:#d2a8ff;font-weight:bold }
+  /* NameFunctionMagic */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .fm { color:#d2a8ff;font-weight:bold }
+  /* Literal */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .l { color:#a5d6ff }
+  /* LiteralDate */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ld { color:#79c0ff }
+  /* LiteralString */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .s { color:#a5d6ff }
+  /* LiteralStringAffix */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sa { color:#79c0ff }
+  /* LiteralStringBacktick */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sb { color:#a5d6ff }
+  /* LiteralStringChar */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sc { color:#a5d6ff }
+  /* LiteralStringDelimiter */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .dl { color:#79c0ff }
+  /* LiteralStringDoc */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sd { color:#a5d6ff }
+  /* LiteralStringDouble */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .s2 { color:#a5d6ff }
+  /* LiteralStringEscape */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .se { color:#79c0ff }
+  /* LiteralStringHeredoc */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sh { color:#79c0ff }
+  /* LiteralStringInterpol */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .si { color:#a5d6ff }
+  /* LiteralStringOther */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sx { color:#a5d6ff }
+  /* LiteralStringRegex */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .sr { color:#79c0ff }
+  /* LiteralStringSingle */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .s1 { color:#a5d6ff }
+  /* LiteralStringSymbol */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ss { color:#a5d6ff }
+  /* LiteralNumber */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .m { color:#a5d6ff }
+  /* LiteralNumberBin */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .mb { color:#a5d6ff }
+  /* LiteralNumberFloat */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .mf { color:#a5d6ff }
+  /* LiteralNumberHex */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .mh { color:#a5d6ff }
+  /* LiteralNumberInteger */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .mi { color:#a5d6ff }
+  /* LiteralNumberIntegerLong */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .il { color:#a5d6ff }
+  /* LiteralNumberOct */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .mo { color:#a5d6ff }
+  /* Operator */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .o { color:#ff7b72;font-weight:bold }
+  /* OperatorWord */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ow { color:#ff7b72;font-weight:bold }
+  /* Comment */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .c { color:#8b949e;font-style:italic }
+  /* CommentHashbang */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ch { color:#8b949e;font-style:italic }
+  /* CommentMultiline */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .cm { color:#8b949e;font-style:italic }
+  /* CommentSingle */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .c1 { color:#8b949e;font-style:italic }
+  /* CommentSpecial */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .cs { color:#8b949e;font-weight:bold;font-style:italic }
+  /* CommentPreproc */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .cp { color:#8b949e;font-weight:bold;font-style:italic }
+  /* CommentPreprocFile */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .cpf { color:#8b949e;font-weight:bold;font-style:italic }
+  /* GenericDeleted */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gd { color:#ffa198;background-color:#490202 }
+  /* GenericEmph */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .ge { font-style:italic }
+  /* GenericError */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gr { color:#ffa198 }
+  /* GenericHeading */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gh { color:#79c0ff;font-weight:bold }
+  /* GenericInserted */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gi { color:#56d364;background-color:#0f5323 }
+  /* GenericOutput */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .go { color:#8b949e }
+  /* GenericPrompt */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gp { color:#8b949e }
+  /* GenericStrong */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gs { font-weight:bold }
+  /* GenericSubheading */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gu { color:#79c0ff }
+  /* GenericTraceback */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gt { color:#ff7b72 }
+  /* GenericUnderline */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .gl { text-decoration:underline }
+  /* TextWhitespace */ :root:not(.dark-mode-on):not(.dark-mode-off) .chroma .w { color:#6e7681 }
+}

--- a/layouts/_markup/render-codeblock.html
+++ b/layouts/_markup/render-codeblock.html
@@ -1,0 +1,3 @@
+{{- $options := merge .Options (dict "noClasses" false) -}}
+{{- $result := transform.HighlightCodeBlock . $options -}}
+{{- $result.Wrapped -}}

--- a/layouts/_markup/render-heading.html
+++ b/layouts/_markup/render-heading.html
@@ -1,3 +1,3 @@
 {{- $disableAnchoredHeadings := .Page.Param "disableAnchoredHeadings" -}}
 {{- $anchor := .Anchor | safeURL -}}
-<h{{ .Level }} id="{{ .Anchor }}">{{ .Text }}{{- if not $disableAnchoredHeadings -}}<a class="anchor" aria-hidden="true" href="#{{ $anchor }}">#</a>{{- end -}}</h{{ .Level }}>
+<h{{ .Level }} id="{{ .Anchor }}">{{ .Text }}{{- if not $disableAnchoredHeadings -}}<a class="anchor" aria-label="Permalink to {{ .PlainText }}" href="#{{ $anchor }}"><span aria-hidden="true">#</span></a>{{- end -}}</h{{ .Level }}>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,8 +25,9 @@
     <link rel="preload" href="{{ "fonts/Newsreader.woff2" | relURL }}" as="font" type="font/woff2" crossorigin>
     {{- end }}
 
-    {{- $defaultCSS := resources.Get "css/default.css" | minify | fingerprint }}
-    <link rel="stylesheet" href="{{ $defaultCSS.RelPermalink }}" integrity="{{ $defaultCSS.Data.Integrity }}">
+    {{- $styles := slice (resources.Get "css/default.css") (resources.Get "css/syntax.css") -}}
+    {{- $themeCSS := $styles | resources.Concat "css/theme.css" | minify | fingerprint }}
+    <link rel="stylesheet" href="{{ $themeCSS.RelPermalink }}" integrity="{{ $themeCSS.Data.Integrity }}">
     {{- with resources.Get "css/custom.css" }}
         {{- with . | minify | fingerprint }}
     <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}">

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -30,6 +30,19 @@ hugo_installed_semver() {
   normalize_semver "$(hugo version | awk '{print $2}')"
 }
 
+verify_vendored_hugo_packages() {
+  require_cmd shasum
+
+  local checksum_file="$HUGO_VENDOR_BIN_DIR/SHA256SUMS"
+  [[ -f "$checksum_file" ]] || die "missing vendored Hugo checksum file: $checksum_file"
+
+  echo -e "${BLUE}Verifying vendored Hugo packages${OFF}"
+  (
+    cd "$HUGO_VENDOR_BIN_DIR"
+    shasum -a 256 -c "$(basename "$checksum_file")"
+  ) || die "vendored Hugo package checksum verification failed"
+}
+
 install_vendored_hugo_linux() {
   require_cmd dpkg
 
@@ -76,6 +89,8 @@ install_hugo_for_ci() {
   if [[ -n "$installed_semver" ]]; then
     echo -e "${BLUE}Detected preinstalled Hugo:${OFF} ${PURPLE}${installed_semver}${OFF}"
   fi
+
+  verify_vendored_hugo_packages
 
   case "$OSTYPE" in
     linux-gnu*)

--- a/script/lib/hugo-fixture.sh
+++ b/script/lib/hugo-fixture.sh
@@ -49,6 +49,21 @@ Hello from the fixture post.[^1]
 
 Some text under a heading.
 
+Inline `vendor/cache` code should keep its compact pill styling.
+
+```bash {linenos=inline hl_lines="2"}
+# Build without downloading modules.
+HUGO_MODULE_PROXY=off hugo --minify
+readonly deliberately_long_path="/this/is/a/deliberately/long/path/that/should/scroll/horizontally/instead/of/breaking/highlighted/tokens/across/the/code/block"
+```
+
+```yaml
+# Pin the reviewed theme revision in go.mod.
+module:
+  imports:
+    - path: github.com/GrantBirki/dario
+```
+
 [^1]: Fixture footnote text.
 EOF
 

--- a/script/test
+++ b/script/test
@@ -61,6 +61,14 @@ if ! grep -Fq 'href="#details"' "$post_html"; then
   die "expected heading anchor link for rendered markdown heading"
 fi
 
+if ! grep -Fq 'aria-label="Permalink to Details"' "$post_html"; then
+  die "heading anchor should have an accessible name derived from the heading"
+fi
+
+if ! grep -Fq '<span aria-hidden="true">#</span>' "$post_html"; then
+  die "heading anchor marker should be hidden from assistive technology"
+fi
+
 if grep -Fq 'href="#without-anchor"' "$no_anchor_html"; then
   die "disableAnchoredHeadings should disable heading anchor links"
 fi
@@ -71,6 +79,38 @@ fi
 
 if grep -q "footnotes" "$home_html"; then
   die "homepage without footnotes should not include footnotes script"
+fi
+
+if [[ "$(grep -Fc 'rel="stylesheet"' "$home_html")" -ne 1 ]]; then
+  die "fixture should load one bundled theme stylesheet"
+fi
+
+if ! grep -Fq 'Inline <code>vendor/cache</code> code' "$post_html"; then
+  die "inline code should render independently from fenced code blocks"
+fi
+
+if ! grep -Fq 'class="chroma"' "$post_html"; then
+  die "fenced code blocks should use class-based Chroma output"
+fi
+
+if ! grep -Fq 'class="language-bash"' "$post_html"; then
+  die "Bash fence language metadata should be preserved"
+fi
+
+if ! grep -Fq 'class="language-yaml"' "$post_html"; then
+  die "YAML fence language metadata should be preserved"
+fi
+
+if ! grep -Fq 'class="ln"' "$post_html" || ! grep -Fq 'class="line hl"' "$post_html"; then
+  die "fenced code block highlighting options should be preserved"
+fi
+
+if grep -Eq '<(div|pre|code|span)[^>]* style=' "$post_html"; then
+  die "Chroma output should not contain inline styles"
+fi
+
+if ! grep -Fq 'deliberately_long_path' "$post_html"; then
+  die "fixture should contain a deliberately long highlighted line"
 fi
 
 if ! grep -Fq "fonts/Newsreader.woff2" "$home_html"; then
@@ -127,6 +167,30 @@ fi
 
 if grep -Fq "url(/fonts/" "$css_file"; then
   die "CSS should not use root-absolute font URLs"
+fi
+
+if ! grep -Fq '.dark-mode-off:root' "$css_file" || ! grep -Fq '#cf222e' "$css_file"; then
+  die "bundled CSS should include the scoped GitHub light syntax palette"
+fi
+
+if ! grep -Fq '.dark-mode-on:root' "$css_file" || ! grep -Fq '#ff7b72' "$css_file"; then
+  die "bundled CSS should include the scoped GitHub dark syntax palette"
+fi
+
+if ! grep -Fq 'prefers-color-scheme:light' "$css_file" || ! grep -Fq 'prefers-color-scheme:dark' "$css_file"; then
+  die "bundled syntax palettes should follow the system color scheme"
+fi
+
+if ! grep -Fq 'overflow-x:auto' "$css_file" || ! grep -Fq 'white-space:pre' "$css_file"; then
+  die "code block panels should preserve long lines and scroll horizontally"
+fi
+
+if ! grep -Fq 'word-break:normal' "$css_file" || ! grep -Fq 'overflow-wrap:normal' "$css_file"; then
+  die "code block panels should not break highlighted tokens"
+fi
+
+if ! grep -Fq 'pre:focus-visible' "$css_file"; then
+  die "scrollable code blocks should expose a visible keyboard focus state"
 fi
 
 if ! grep -Fq "../fonts/Newsreader.woff2" "$output_dir"/og/*.svg; then


### PR DESCRIPTION
## Summary

Code examples now use class-based Chroma highlighting with matching GitHub light and dark palettes, while fenced options, inline-code pills, narrow-screen scrolling, and visible keyboard focus stay intact.

Heading permalinks now expose accessible names and keyboard-visible states, and bootstrap verifies both vendored Hugo 0.156.0 installers against official SHA-256 digests before privileged installation.

The fixture covers inline code, Bash and YAML fences, comments, long lines, both palettes, and class output; module documentation now uses reviewed 40-character revisions with `go.mod` as the dependency authority.

This intentionally does not add release tags, change the pinned Hugo version, audit font provenance, or include unrelated markup cleanup.
