### PR TITLE
Add configurable Copy Markdown controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,24 @@ By default, the theme shows a toggle for switching between light and dark modes.
 
 You can also set it to `'light'` or `'dark'` to keep it fixed. The default behavior is to have it set as `'toggle'` which displays a toggle and on first page load it defaults to the user's system preference.
 
+The optional Copy Markdown control is disabled by default. Enable it on both the landing page and post pages with:
+
+```toml
+[params.copyMarkdown]
+  enabled = true
+```
+
+To show it on only one page type, set `home` or `posts` explicitly. An omitted page switch defaults to enabled while the feature is enabled globally:
+
+```toml
+[params.copyMarkdown]
+  enabled = true
+  home = true
+  posts = false
+```
+
+The control copies a Markdown heading and the page's raw Markdown body. Landing-page copies also include the generated section and post links, making the result ready to paste into an LLM prompt or another Markdown-aware tool.
+
 The home page shows the top-level section with the most pages by default. To override this, set `mainSections` to select specific sections:
 
 ```toml

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -477,6 +477,58 @@ center {
   line-height: 1.4;
 }
 
+.page-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75em;
+  margin-block-start: 2em;
+}
+
+.page-meta .author-date {
+  margin-block: 0;
+}
+
+.page-meta-home {
+  margin-block-start: 1em;
+}
+
+.copy-markdown-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+  min-block-size: 2.25em;
+  padding: 0.35em 0.65em;
+  color: var(--muted-text-color);
+  background-color: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5em;
+  font: inherit;
+  font-size: 0.8em;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.copy-markdown-button:hover {
+  color: var(--text-color);
+  background-color: var(--footnote-bg-color);
+}
+
+.copy-markdown-button:focus-visible {
+  outline: 2px solid var(--focus-color);
+  outline-offset: 2px;
+}
+
+.copy-markdown-button:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.copy-markdown-icon {
+  flex: none;
+  fill: currentColor;
+}
+
 .mobile-toc-link,
 .toc-container h2 {
   font-size: 1.2em;

--- a/assets/js/copy-markdown.js
+++ b/assets/js/copy-markdown.js
@@ -1,0 +1,63 @@
+"use strict";
+
+function copyMarkdownFallback(markdown) {
+  const textarea = document.createElement("textarea");
+  textarea.value = markdown;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand("copy");
+  textarea.remove();
+
+  if (!copied) {
+    throw new Error("Copy command failed");
+  }
+}
+
+async function copyMarkdown(markdown) {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(markdown);
+    return;
+  }
+
+  copyMarkdownFallback(markdown);
+}
+
+function initializeCopyMarkdownButton(button) {
+  const label = button.querySelector(".copy-markdown-label");
+  const source = document.getElementById(button.dataset.copyMarkdownTarget);
+
+  if (!label || !source) {
+    return;
+  }
+
+  const defaultLabel = label.textContent;
+  button.addEventListener("click", async () => {
+    button.disabled = true;
+
+    try {
+      await copyMarkdown(JSON.parse(source.textContent));
+      label.textContent = "Copied!";
+    } catch (_error) {
+      label.textContent = "Copy failed";
+    }
+
+    button.disabled = false;
+    button.focus();
+    window.setTimeout(() => {
+      label.textContent = defaultLabel;
+    }, 2000);
+  });
+}
+
+function initializeCopyMarkdownButtons() {
+  document.querySelectorAll(".copy-markdown-button").forEach(initializeCopyMarkdownButton);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeCopyMarkdownButtons);
+} else {
+  initializeCopyMarkdownButtons();
+}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,17 @@
 {{- define "main" }}
+    {{- $copyMarkdownEnabled := partial "copy-markdown/enabled.html" . }}
     <h1>{{ .Title | .RenderString }}</h1>
     <h4>{{ .Params.description }}</h4>
 
-    {{- if isset .Params "date" }}
-    <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
+    {{- if or (isset .Params "date") $copyMarkdownEnabled }}
+    <div class="page-meta">
+        {{- if isset .Params "date" }}
+        <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
+        {{- end }}
+        {{- if $copyMarkdownEnabled }}
+{{ partial "copy-markdown/button.html" . }}
+        {{- end }}
+    </div>
     {{- end }}
 
 {{ .Content }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,9 +1,16 @@
 {{- define "main" }}
+    {{- $home := . }}
+    {{- $copyMarkdownEnabled := partial "copy-markdown/enabled.html" . }}
     {{- with .Site.GetPage "_index.md" }}
         {{- if .Params.homePageIsPost }}
     <h1>{{ .Title | .RenderString }}</h1>
     <h4>{{ .Params.description }}</h4>
-    <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
+    <div class="page-meta">
+        <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
+        {{- if $copyMarkdownEnabled }}
+{{ partial "copy-markdown/button.html" $home }}
+        {{- end }}
+    </div>
 
 {{ .Content }}
         {{- else }}
@@ -13,6 +20,11 @@
     <h1 class="smaller">{{ $subtitle }}</h1>
 {{ . }}
     </section>
+            {{- end }}
+            {{- if $copyMarkdownEnabled }}
+    <div class="page-meta page-meta-home">
+{{ partial "copy-markdown/button.html" $home }}
+    </div>
             {{- end }}
         {{- end }}
     {{- end }}

--- a/layouts/partials/copy-markdown/button.html
+++ b/layouts/partials/copy-markdown/button.html
@@ -1,0 +1,9 @@
+{{- $markdown := partial "copy-markdown/content.html" . -}}
+<button type="button" class="copy-markdown-button" data-copy-markdown-target="copy-markdown-source">
+    <svg class="copy-markdown-icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M7.024 3.75c0-.966.784-1.75 1.75-1.75H20.25c.966 0 1.75.784 1.75 1.75v11.498a1.75 1.75 0 0 1-1.75 1.75H8.774a1.75 1.75 0 0 1-1.75-1.75Zm1.75-.25a.25.25 0 0 0-.25.25v11.498c0 .139.112.25.25.25H20.25a.25.25 0 0 0 .25-.25V3.75a.25.25 0 0 0-.25-.25Z" />
+        <path d="M1.995 10.749a1.75 1.75 0 0 1 1.75-1.751H5.25a.75.75 0 1 1 0 1.5H3.745a.25.25 0 0 0-.25.25L3.5 20.25c0 .138.111.25.25.25h9.5a.25.25 0 0 0 .25-.25v-1.51a.75.75 0 1 1 1.5 0v1.51A1.75 1.75 0 0 1 13.25 22h-9.5A1.75 1.75 0 0 1 2 20.25l-.005-9.501Z" />
+    </svg>
+    <span class="copy-markdown-label" aria-live="polite">Copy Markdown</span>
+</button>
+<script type="application/json" id="copy-markdown-source">{{ $markdown | jsonify | safeJS }}</script>

--- a/layouts/partials/copy-markdown/content.html
+++ b/layouts/partials/copy-markdown/content.html
@@ -1,0 +1,21 @@
+{{- $source := . -}}
+{{- if .IsHome -}}
+    {{- with .Site.GetPage "_index.md" }}{{- $source = . -}}{{- end -}}
+{{- end -}}
+{{- $title := $source.Title | $source.RenderString | plainify | htmlUnescape -}}
+{{- $markdown := printf "# %s\n" $title -}}
+{{- with strings.TrimSpace $source.RawContent -}}
+    {{- $markdown = printf "%s\n%s\n" $markdown . -}}
+{{- end -}}
+{{- if .IsHome -}}
+    {{- range sort (where .Site.Sections "Section" "in" .Site.MainSections) "Weight" -}}
+        {{- $sectionTitle := .Title | .RenderString | plainify | htmlUnescape -}}
+        {{- $markdown = printf "%s\n## %s\n" $markdown $sectionTitle -}}
+        {{- range where .Site.RegularPages "Section" .Section -}}
+            {{- $pageTitle := .Title | .RenderString | plainify | htmlUnescape -}}
+            {{- $markdown = printf "%s\n- [%s](%s)" $markdown $pageTitle .Permalink -}}
+        {{- end -}}
+        {{- $markdown = printf "%s\n" $markdown -}}
+    {{- end -}}
+{{- end -}}
+{{- return printf "%s\n" (strings.TrimSpace $markdown) -}}

--- a/layouts/partials/copy-markdown/enabled.html
+++ b/layouts/partials/copy-markdown/enabled.html
@@ -1,0 +1,14 @@
+{{- $enabled := false -}}
+{{- with .Site.Params.copyMarkdown -}}
+    {{- if .enabled -}}
+        {{- $enabled = true -}}
+        {{- if $.IsHome -}}
+            {{- if isset . "home" }}{{- $enabled = .home -}}{{- end -}}
+        {{- else if $.IsPage -}}
+            {{- if isset . "posts" }}{{- $enabled = .posts -}}{{- end -}}
+        {{- else -}}
+            {{- $enabled = false -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- return $enabled -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -46,6 +46,11 @@
     <script src="{{ $darkmodeJS.RelPermalink }}" integrity="{{ $darkmodeJS.Data.Integrity }}" defer></script>
     {{- end }}
 
+    {{- if partial "copy-markdown/enabled.html" . }}
+    {{- $copyMarkdownJS := resources.Get "js/copy-markdown.js" | minify | fingerprint }}
+    <script src="{{ $copyMarkdownJS.RelPermalink }}" integrity="{{ $copyMarkdownJS.Data.Integrity }}" defer></script>
+    {{- end }}
+
     {{- with .Content }}
         {{- if or (in . "id=\"fnref") (in . "class=\"footnote-ref\"") }}
             {{- $footnotesJS := resources.Get "js/footnotes.js" | minify | fingerprint }}

--- a/script/lib/hugo-fixture.sh
+++ b/script/lib/hugo-fixture.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 create_hugo_fixture_site() {
   local site_dir="$1"
   local theme_dir="$2"
+  local copy_markdown_mode="${3:-global}"
+  local home_page_is_post="${4:-true}"
 
   mkdir -p "$site_dir/content/posts" "$site_dir/themes"
   ln -s "$theme_dir" "$site_dir/themes/dario"
@@ -22,12 +24,51 @@ theme = "dario"
   name = "Fixture Author"
 EOF
 
-  cat > "$site_dir/content/_index.md" <<'EOF'
+  case "$copy_markdown_mode" in
+    global)
+      cat >> "$site_dir/hugo.toml" <<'EOF'
+
+[params.copyMarkdown]
+  enabled = true
+EOF
+      ;;
+    home)
+      cat >> "$site_dir/hugo.toml" <<'EOF'
+
+[params.copyMarkdown]
+  enabled = true
+  home = true
+  posts = false
+EOF
+      ;;
+    posts)
+      cat >> "$site_dir/hugo.toml" <<'EOF'
+
+[params.copyMarkdown]
+  enabled = true
+  home = false
+  posts = true
+EOF
+      ;;
+    off)
+      cat >> "$site_dir/hugo.toml" <<'EOF'
+
+[params.copyMarkdown]
+  enabled = false
+EOF
+      ;;
+    *)
+      echo "unsupported copy Markdown fixture mode: $copy_markdown_mode" >&2
+      return 1
+      ;;
+  esac
+
+  cat > "$site_dir/content/_index.md" <<EOF
 +++
 title = "Home *Post*"
 subtitle = "Fixture subtitle"
 description = "Fixture homepage description"
-homePageIsPost = true
+homePageIsPost = $home_page_is_post
 date = 2025-02-24T00:00:00Z
 author = "Fixture Author"
 +++

--- a/script/test
+++ b/script/test
@@ -33,6 +33,7 @@ absolute_og_html="$output_dir/posts/absolute-og/index.html"
 no_anchor_html="$output_dir/posts/no-anchors/index.html"
 template_literal_og_html="$output_dir/posts/template-literal-og/index.html"
 css_file="$(ls "$output_dir"/css/*.css | head -n1)"
+copy_markdown_js_file="$(ls "$output_dir"/js/copy-markdown*.js | head -n1)"
 
 [[ -f "$home_html" ]] || die "expected fixture homepage output at $home_html"
 [[ -f "$post_html" ]] || die "expected fixture post output at $post_html"
@@ -40,6 +41,7 @@ css_file="$(ls "$output_dir"/css/*.css | head -n1)"
 [[ -f "$no_anchor_html" ]] || die "expected fixture no-anchors output at $no_anchor_html"
 [[ -f "$template_literal_og_html" ]] || die "expected template-literal-og output at $template_literal_og_html"
 [[ -f "$css_file" ]] || die "expected processed CSS output under $output_dir/css"
+[[ -f "$copy_markdown_js_file" ]] || die "expected processed copy Markdown JavaScript under $output_dir/js"
 
 if ! grep -Fq "<h1>Home <em>Post</em></h1>" "$home_html"; then
   die "homepage title markdown did not render as expected"
@@ -55,6 +57,38 @@ fi
 
 if ! grep -Fq "<h1>First <em>Post</em></h1>" "$post_html"; then
   die "single post title markdown did not render as expected"
+fi
+
+if ! grep -Fq 'class="copy-markdown-button"' "$home_html" || ! grep -Fq 'class="copy-markdown-button"' "$post_html"; then
+  die "global copy Markdown configuration should enable the control on home and post pages"
+fi
+
+if ! grep -Fq '<span class="copy-markdown-label" aria-live="polite">Copy Markdown</span>' "$post_html"; then
+  die "copy Markdown control should expose visible status text to assistive technology"
+fi
+
+if ! grep -Fq 'class="copy-markdown-icon"' "$post_html" || ! grep -Fq 'aria-hidden="true"' "$post_html"; then
+  die "copy Markdown icon should be decorative"
+fi
+
+if ! grep -Fq 'type="application/json" id="copy-markdown-source"' "$post_html"; then
+  die "copy Markdown control should include a JSON-encoded source payload"
+fi
+
+if ! grep -Fq '# First Post' "$post_html" || ! grep -Fq 'Hello from the fixture post.' "$post_html"; then
+  die "post copy payload should include the plain title and raw Markdown body"
+fi
+
+if ! grep -Fq '# Home Post' "$home_html" || ! grep -Fq '## Posts' "$home_html" || ! grep -Fq -- '- [First Post](https://example.org/blog/posts/first/)' "$home_html"; then
+  die "home copy payload should include its content and generated post links"
+fi
+
+if ! grep -Fq 'navigator.clipboard' "$copy_markdown_js_file" || ! grep -Fq 'execCommand("copy")' "$copy_markdown_js_file"; then
+  die "copy Markdown JavaScript should include Clipboard API and compatibility fallback paths"
+fi
+
+if ! grep -Fq '.copy-markdown-button:focus-visible' "$css_file"; then
+  die "copy Markdown control should expose a visible keyboard focus state"
 fi
 
 if ! grep -Fq 'href="#details"' "$post_html"; then
@@ -204,5 +238,45 @@ fi
 if ! grep -q "A &amp; B" "$output_dir"/og/*.svg; then
   die "OG SVG is missing escaped description content"
 fi
+
+assert_copy_markdown_mode() {
+  local mode="$1"
+  local expect_home="$2"
+  local expect_post="$3"
+  local mode_site="$work_dir/site-$mode"
+  local mode_output="$work_dir/public-$mode"
+
+  create_hugo_fixture_site "$mode_site" "$DIR" "$mode"
+  hugo --quiet --source "$mode_site" --destination "$mode_output" --panicOnWarning
+
+  if [[ "$expect_home" == "true" ]]; then
+    grep -Fq 'class="copy-markdown-button"' "$mode_output/index.html" || die "$mode mode should enable copy Markdown on the homepage"
+    grep -Fq '/js/copy-markdown.' "$mode_output/index.html" || die "$mode mode homepage should load copy Markdown JavaScript"
+  elif grep -Fq 'class="copy-markdown-button"' "$mode_output/index.html"; then
+    die "$mode mode should disable copy Markdown on the homepage"
+  elif grep -Fq '/js/copy-markdown.' "$mode_output/index.html"; then
+    die "$mode mode homepage should not load unused copy Markdown JavaScript"
+  fi
+
+  if [[ "$expect_post" == "true" ]]; then
+    grep -Fq 'class="copy-markdown-button"' "$mode_output/posts/first/index.html" || die "$mode mode should enable copy Markdown on post pages"
+    grep -Fq '/js/copy-markdown.' "$mode_output/posts/first/index.html" || die "$mode mode posts should load copy Markdown JavaScript"
+  elif grep -Fq 'class="copy-markdown-button"' "$mode_output/posts/first/index.html"; then
+    die "$mode mode should disable copy Markdown on post pages"
+  elif grep -Fq '/js/copy-markdown.' "$mode_output/posts/first/index.html"; then
+    die "$mode mode posts should not load unused copy Markdown JavaScript"
+  fi
+}
+
+assert_copy_markdown_mode home true false
+assert_copy_markdown_mode posts false true
+assert_copy_markdown_mode off false false
+
+landing_site="$work_dir/site-landing"
+landing_output="$work_dir/public-landing"
+create_hugo_fixture_site "$landing_site" "$DIR" global false
+hugo --quiet --source "$landing_site" --destination "$landing_output" --panicOnWarning
+grep -Fq 'class="page-meta page-meta-home"' "$landing_output/index.html" || die "standard landing page should render the copy Markdown control"
+grep -Fq '# Home Post' "$landing_output/index.html" || die "standard landing page should include its Markdown payload"
 
 echo -e "${GREEN}Fixture tests passed${OFF}"

--- a/theme.toml
+++ b/theme.toml
@@ -17,6 +17,7 @@ tags = [
 
 features = [
   "blog",
+  "copy-markdown",
   "opengraph",
   "theme-toggle"
 ]


### PR DESCRIPTION
Adds an optional Copy Markdown control to landing and post pages, making their source content easy to paste into LLM prompts and other Markdown-aware tools. The feature stays off by default; `params.copyMarkdown.enabled = true` enables both page types, while `home` and `posts` provide independent overrides.

The compact control uses a familiar stacked-copy icon, preserves raw post Markdown, and adds generated section links when copying the landing page. It is dependency-free, keyboard accessible, responsive, and only loads its fingerprinted JavaScript on pages where the control is enabled.
