### PR TITLE
Refine page controls and add optional posts link

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ By default, the theme shows a toggle for switching between light and dark modes.
 
 You can also set it to `'light'` or `'dark'` to keep it fixed. The default behavior is to have it set as `'toggle'` which displays a toggle and on first page load it defaults to the user's system preference.
 
+The lowercase `posts` link in the header is disabled by default. Enable it on every page with:
+
+```toml
+[params]
+  showPostsLink = true
+```
+
 The optional Copy Markdown control is disabled by default. Enable it on both the landing page and post pages with:
 
 ```toml

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -58,6 +58,8 @@ header h1 a {
   --code-block-bg: #0d1117;
   --code-block-border: #30363d;
   --muted-text-color: #b3b3b3;
+  --control-border-color: #444;
+  --control-bg-color: transparent;
 }
 
 .dark-mode-off:root {
@@ -81,6 +83,8 @@ header h1 a {
   --code-block-bg: #f7f7f7;
   --code-block-border: #d0d7de;
   --muted-text-color: #666666;
+  --control-border-color: #85827b;
+  --control-bg-color: rgba(255, 255, 255, 0.35);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -105,6 +109,8 @@ header h1 a {
     --code-block-bg: #0d1117;
     --code-block-border: #30363d;
     --muted-text-color: #b3b3b3;
+    --control-border-color: #444;
+    --control-bg-color: transparent;
   }
 }
 
@@ -130,6 +136,8 @@ header h1 a {
     --code-block-bg: #f7f7f7;
     --code-block-border: #d0d7de;
     --muted-text-color: #666666;
+    --control-border-color: #85827b;
+    --control-bg-color: rgba(255, 255, 255, 0.35);
   }
 }
 
@@ -320,8 +328,13 @@ header h1 a {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  inline-size: 250px;
+  inline-size: 100%;
   padding-block-start: 2px;
+}
+
+header h1 {
+  flex: 0 1 250px;
+  min-inline-size: 0;
 }
 
 header h1 a {
@@ -345,6 +358,23 @@ p a:hover {
   opacity: 1;
   pointer-events: auto;
   transition: opacity 0.2s ease;
+}
+
+.header-posts-link {
+  color: var(--muted-text-color);
+  font-size: 0.75em;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.header-posts-link:hover {
+  color: var(--text-color);
+}
+
+.header-posts-link:focus-visible {
+  outline: 2px solid var(--focus-color);
+  outline-offset: 3px;
 }
 
 /* Toggle Switch Styles */
@@ -479,8 +509,8 @@ center {
 
 .page-meta {
   display: flex;
-  align-items: center;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 0.75em;
   margin-block-start: 2em;
 }
@@ -500,8 +530,8 @@ center {
   min-block-size: 2.25em;
   padding: 0.35em 0.65em;
   color: var(--muted-text-color);
-  background-color: transparent;
-  border: 1px solid var(--border-color);
+  background-color: var(--control-bg-color);
+  border: 1px solid var(--control-border-color);
   border-radius: 0.5em;
   font: inherit;
   font-size: 0.8em;

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,11 +5,11 @@
 
     {{- if or (isset .Params "date") $copyMarkdownEnabled }}
     <div class="page-meta">
-        {{- if isset .Params "date" }}
-        <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
-        {{- end }}
         {{- if $copyMarkdownEnabled }}
 {{ partial "copy-markdown/button.html" . }}
+        {{- end }}
+        {{- if isset .Params "date" }}
+        <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
         {{- end }}
     </div>
     {{- end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,10 +6,10 @@
     <h1>{{ .Title | .RenderString }}</h1>
     <h4>{{ .Params.description }}</h4>
     <div class="page-meta">
-        <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
         {{- if $copyMarkdownEnabled }}
 {{ partial "copy-markdown/button.html" $home }}
         {{- end }}
+        <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
     </div>
 
 {{ .Content }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
         </h1>
         <div class="header-controls">
             {{- if .Site.Params.showPostsLink }}
-            <a class="header-posts-link" href="{{ "posts/" | relURL }}">posts</a>
+            <a class="header-posts-link" href="{{ "posts/" | relLangURL }}">posts</a>
             {{- end }}
             <div class="toggle-switch">
                 <input type="checkbox" id="darkModeToggle" class="toggle-input" aria-label="Toggle dark mode">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,6 +4,9 @@
             <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
         </h1>
         <div class="header-controls">
+            {{- if .Site.Params.showPostsLink }}
+            <a class="header-posts-link" href="{{ "posts/" | relURL }}">posts</a>
+            {{- end }}
             <div class="toggle-switch">
                 <input type="checkbox" id="darkModeToggle" class="toggle-input" aria-label="Toggle dark mode">
                 <label for="darkModeToggle" class="toggle-label">

--- a/script/lib/hugo-fixture.sh
+++ b/script/lib/hugo-fixture.sh
@@ -7,11 +7,12 @@ create_hugo_fixture_site() {
   local theme_dir="$2"
   local copy_markdown_mode="${3:-global}"
   local home_page_is_post="${4:-true}"
+  local show_posts_link="${5:-true}"
 
   mkdir -p "$site_dir/content/posts" "$site_dir/themes"
   ln -s "$theme_dir" "$site_dir/themes/dario"
 
-  cat > "$site_dir/hugo.toml" <<'EOF'
+  cat > "$site_dir/hugo.toml" <<EOF
 baseURL = "https://example.org/blog/"
 languageCode = "en-us"
 title = "Fixture Site"
@@ -19,6 +20,7 @@ theme = "dario"
 
 [params]
   description = "Fixture description"
+  showPostsLink = $show_posts_link
 
 [params.author]
   name = "Fixture Author"

--- a/script/test
+++ b/script/test
@@ -323,4 +323,31 @@ if grep -Rq 'class="header-posts-link"' "$posts_link_off_output"; then
   die "disabled posts link should not render on any page"
 fi
 
+multilingual_site="$work_dir/site-multilingual"
+multilingual_output="$work_dir/public-multilingual"
+create_hugo_fixture_site "$multilingual_site" "$DIR"
+cat >> "$multilingual_site/hugo.toml" <<'EOF'
+
+[languages.en]
+  languageCode = "en-us"
+  weight = 1
+
+[languages.fr]
+  languageCode = "fr-fr"
+  weight = 2
+EOF
+cat > "$multilingual_site/content/posts/first.fr.md" <<'EOF'
++++
+title = "Premier article"
+description = "Article de test"
+date = 2025-02-24T00:00:00Z
++++
+
+Contenu de test.
+EOF
+hugo --quiet --source "$multilingual_site" --destination "$multilingual_output" --panicOnWarning
+if ! grep -Fq '<a class="header-posts-link" href="/blog/fr/posts/">posts</a>' "$multilingual_output/fr/posts/first/index.html"; then
+  die "posts header link should include the active language path"
+fi
+
 echo -e "${GREEN}Fixture tests passed${OFF}"

--- a/script/test
+++ b/script/test
@@ -29,6 +29,7 @@ hugo \
 
 home_html="$output_dir/index.html"
 post_html="$output_dir/posts/first/index.html"
+posts_html="$output_dir/posts/index.html"
 absolute_og_html="$output_dir/posts/absolute-og/index.html"
 no_anchor_html="$output_dir/posts/no-anchors/index.html"
 template_literal_og_html="$output_dir/posts/template-literal-og/index.html"
@@ -37,6 +38,7 @@ copy_markdown_js_file="$(ls "$output_dir"/js/copy-markdown*.js | head -n1)"
 
 [[ -f "$home_html" ]] || die "expected fixture homepage output at $home_html"
 [[ -f "$post_html" ]] || die "expected fixture post output at $post_html"
+[[ -f "$posts_html" ]] || die "expected fixture posts output at $posts_html"
 [[ -f "$absolute_og_html" ]] || die "expected fixture absolute-og output at $absolute_og_html"
 [[ -f "$no_anchor_html" ]] || die "expected fixture no-anchors output at $no_anchor_html"
 [[ -f "$template_literal_og_html" ]] || die "expected template-literal-og output at $template_literal_og_html"
@@ -62,6 +64,28 @@ fi
 if ! grep -Fq 'class="copy-markdown-button"' "$home_html" || ! grep -Fq 'class="copy-markdown-button"' "$post_html"; then
   die "global copy Markdown configuration should enable the control on home and post pages"
 fi
+
+assert_copy_button_before_date() {
+  local page="$1"
+  local copy_line
+  local date_line
+
+  copy_line="$(grep -n -m1 'class="copy-markdown-button"' "$page")"
+  copy_line="${copy_line%%:*}"
+  date_line="$(grep -n -m1 'class="author-date"' "$page")"
+  date_line="${date_line%%:*}"
+
+  [[ "$copy_line" -lt "$date_line" ]] || die "copy Markdown control should render above the date in $page"
+}
+
+assert_copy_button_before_date "$home_html"
+assert_copy_button_before_date "$post_html"
+
+for page in "$home_html" "$post_html" "$posts_html"; do
+  if ! grep -Fq '<a class="header-posts-link" href="/blog/posts/">posts</a>' "$page"; then
+    die "enabled posts link should render in the header on $page"
+  fi
+done
 
 if ! grep -Fq '<span class="copy-markdown-label" aria-live="polite">Copy Markdown</span>' "$post_html"; then
   die "copy Markdown control should expose visible status text to assistive technology"
@@ -89,6 +113,18 @@ fi
 
 if ! grep -Fq '.copy-markdown-button:focus-visible' "$css_file"; then
   die "copy Markdown control should expose a visible keyboard focus state"
+fi
+
+if ! grep -Fq -- '--control-border-color:#85827b' "$css_file" || ! grep -Fq -- '--control-bg-color:rgba(255, 255, 255, 0.35)' "$css_file"; then
+  die "copy Markdown control should have a distinct light-mode edge and surface"
+fi
+
+if ! grep -Fq '.page-meta{display:flex;flex-direction:column;align-items:flex-start' "$css_file"; then
+  die "page metadata should stack the copy Markdown control above the date"
+fi
+
+if ! grep -Fq '.header-posts-link:focus-visible' "$css_file"; then
+  die "posts header link should expose a visible keyboard focus state"
 fi
 
 if ! grep -Fq 'href="#details"' "$post_html"; then
@@ -278,5 +314,13 @@ create_hugo_fixture_site "$landing_site" "$DIR" global false
 hugo --quiet --source "$landing_site" --destination "$landing_output" --panicOnWarning
 grep -Fq 'class="page-meta page-meta-home"' "$landing_output/index.html" || die "standard landing page should render the copy Markdown control"
 grep -Fq '# Home Post' "$landing_output/index.html" || die "standard landing page should include its Markdown payload"
+
+posts_link_off_site="$work_dir/site-posts-link-off"
+posts_link_off_output="$work_dir/public-posts-link-off"
+create_hugo_fixture_site "$posts_link_off_site" "$DIR" global true false
+hugo --quiet --source "$posts_link_off_site" --destination "$posts_link_off_output" --panicOnWarning
+if grep -Rq 'class="header-posts-link"' "$posts_link_off_output"; then
+  die "disabled posts link should not render on any page"
+fi
 
 echo -e "${GREEN}Fixture tests passed${OFF}"

--- a/theme.toml
+++ b/theme.toml
@@ -19,6 +19,7 @@ features = [
   "blog",
   "copy-markdown",
   "opengraph",
+  "posts-link",
   "theme-toggle"
 ]
 


### PR DESCRIPTION
Moves Copy Markdown into its own row above page dates on the landing and post layouts, with a clearer light-mode border and surface.

Adds an optional lowercase `posts` header link controlled by `params.showPostsLink`, disabled by default and aware of sites hosted below a base path. The responsive header styling keeps the title, link, and theme toggle from overlapping on narrow screens.
