### PR TITLE
Refine header and page metadata spacing

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -354,7 +354,7 @@ p a:hover {
 .header-controls {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   opacity: 1;
   pointer-events: auto;
   transition: opacity 0.2s ease;
@@ -362,7 +362,7 @@ p a:hover {
 
 .header-posts-link {
   color: var(--muted-text-color);
-  font-size: 0.75em;
+  font-size: 0.85em;
   line-height: 1;
   text-decoration: none;
   white-space: nowrap;
@@ -375,6 +375,13 @@ p a:hover {
 .header-posts-link:focus-visible {
   outline: 2px solid var(--focus-color);
   outline-offset: 3px;
+}
+
+.header-control-separator {
+  inline-size: 1px;
+  block-size: 1.1em;
+  background-color: var(--muted-text-color);
+  opacity: 0.65;
 }
 
 /* Toggle Switch Styles */
@@ -511,8 +518,8 @@ center {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.75em;
-  margin-block-start: 2em;
+  gap: 1em;
+  margin-block: 1.5em;
 }
 
 .page-meta .author-date {

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,11 +5,11 @@
 
     {{- if or (isset .Params "date") $copyMarkdownEnabled }}
     <div class="page-meta">
-        {{- if $copyMarkdownEnabled }}
-{{ partial "copy-markdown/button.html" . }}
-        {{- end }}
         {{- if isset .Params "date" }}
         <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
+        {{- end }}
+        {{- if $copyMarkdownEnabled }}
+{{ partial "copy-markdown/button.html" . }}
         {{- end }}
     </div>
     {{- end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,10 +6,10 @@
     <h1>{{ .Title | .RenderString }}</h1>
     <h4>{{ .Params.description }}</h4>
     <div class="page-meta">
+        <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
         {{- if $copyMarkdownEnabled }}
 {{ partial "copy-markdown/button.html" $home }}
         {{- end }}
-        <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
     </div>
 
 {{ .Content }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,6 +6,7 @@
         <div class="header-controls">
             {{- if .Site.Params.showPostsLink }}
             <a class="header-posts-link" href="{{ "posts/" | relLangURL }}">posts</a>
+            <span class="header-control-separator" aria-hidden="true"></span>
             {{- end }}
             <div class="toggle-switch">
                 <input type="checkbox" id="darkModeToggle" class="toggle-input" aria-label="Toggle dark mode">

--- a/script/test
+++ b/script/test
@@ -65,7 +65,7 @@ if ! grep -Fq 'class="copy-markdown-button"' "$home_html" || ! grep -Fq 'class="
   die "global copy Markdown configuration should enable the control on home and post pages"
 fi
 
-assert_copy_button_before_date() {
+assert_date_before_copy_button() {
   local page="$1"
   local copy_line
   local date_line
@@ -75,17 +75,21 @@ assert_copy_button_before_date() {
   date_line="$(grep -n -m1 'class="author-date"' "$page")"
   date_line="${date_line%%:*}"
 
-  [[ "$copy_line" -lt "$date_line" ]] || die "copy Markdown control should render above the date in $page"
+  [[ "$date_line" -lt "$copy_line" ]] || die "copy Markdown control should render below the date in $page"
 }
 
-assert_copy_button_before_date "$home_html"
-assert_copy_button_before_date "$post_html"
+assert_date_before_copy_button "$home_html"
+assert_date_before_copy_button "$post_html"
 
 for page in "$home_html" "$post_html" "$posts_html"; do
   if ! grep -Fq '<a class="header-posts-link" href="/blog/posts/">posts</a>' "$page"; then
     die "enabled posts link should render in the header on $page"
   fi
 done
+
+if ! grep -Fq '<span class="header-control-separator" aria-hidden="true"></span>' "$home_html"; then
+  die "posts header link should include a decorative separator before the theme toggle"
+fi
 
 if ! grep -Fq '<span class="copy-markdown-label" aria-live="polite">Copy Markdown</span>' "$post_html"; then
   die "copy Markdown control should expose visible status text to assistive technology"
@@ -119,12 +123,16 @@ if ! grep -Fq -- '--control-border-color:#85827b' "$css_file" || ! grep -Fq -- '
   die "copy Markdown control should have a distinct light-mode edge and surface"
 fi
 
-if ! grep -Fq '.page-meta{display:flex;flex-direction:column;align-items:flex-start' "$css_file"; then
-  die "page metadata should stack the copy Markdown control above the date"
+if ! grep -Fq '.page-meta{display:flex;flex-direction:column;align-items:flex-start;gap:1em;margin-block:1.5em}' "$css_file"; then
+  die "page metadata should use even vertical spacing"
 fi
 
 if ! grep -Fq '.header-posts-link:focus-visible' "$css_file"; then
   die "posts header link should expose a visible keyboard focus state"
+fi
+
+if ! grep -Fq 'font-size:.85em' "$css_file" || ! grep -Fq '.header-control-separator' "$css_file"; then
+  die "posts header controls should include the larger label and separator styling"
 fi
 
 if ! grep -Fq 'href="#details"' "$post_html"; then
@@ -319,8 +327,8 @@ posts_link_off_site="$work_dir/site-posts-link-off"
 posts_link_off_output="$work_dir/public-posts-link-off"
 create_hugo_fixture_site "$posts_link_off_site" "$DIR" global true false
 hugo --quiet --source "$posts_link_off_site" --destination "$posts_link_off_output" --panicOnWarning
-if grep -Rq 'class="header-posts-link"' "$posts_link_off_output"; then
-  die "disabled posts link should not render on any page"
+if grep -Rq 'class="header-posts-link"' "$posts_link_off_output" || grep -Rq 'class="header-control-separator"' "$posts_link_off_output"; then
+  die "disabled posts link and separator should not render on any page"
 fi
 
 multilingual_site="$work_dir/site-multilingual"


### PR DESCRIPTION
Adds a thin decorative separator between the optional `posts` link and theme toggle, and increases the link text slightly for easier scanning.

Moves Copy Markdown below the date and gives the tagline, date, button, and following content a more even vertical rhythm. The responsive header continues to shrink cleanly without overlap on narrow screens.
