### PR TITLE
Add Fence v0.8.7 runner hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,15 @@ jobs:
     name: build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
+      - if: matrix.os == 'ubuntu-24.04'
+        uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - if: matrix.os == 'ubuntu-24.04'
         uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - if: matrix.os == 'ubuntu-24.04'
         uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,15 @@ jobs:
     name: lint
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
+      - if: matrix.os == 'ubuntu-24.04'
+        uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,15 @@ jobs:
     name: test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
+      - if: matrix.os == 'ubuntu-24.04'
+        uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - if: matrix.os == 'ubuntu-24.04'
         uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -44,14 +44,20 @@ verify_vendored_hugo_packages() {
 }
 
 install_vendored_hugo_linux() {
-  require_cmd dpkg
+  require_cmd dpkg-deb
 
   local version="$1"
   local deb_pkg="$HUGO_VENDOR_BIN_DIR/hugo_extended_${version}_linux-amd64.deb"
   [[ -f "$deb_pkg" ]] || die "missing vendored Hugo package: $deb_pkg"
 
   echo -e "${BLUE}Installing vendored Hugo package:${OFF} ${PURPLE}${deb_pkg}${OFF}"
-  as_root dpkg -i "$deb_pkg"
+  local install_root="${RUNNER_TEMP:-$TMP_DIR}/hugo-${version}"
+  mkdir -p "$install_root"
+  dpkg-deb --extract "$deb_pkg" "$install_root"
+  export PATH="$install_root/usr/local/bin:$PATH"
+  if [[ -n "${GITHUB_PATH:-}" ]]; then
+    printf '%s\n' "$install_root/usr/local/bin" >> "$GITHUB_PATH"
+  fi
 }
 
 install_vendored_hugo_macos() {


### PR DESCRIPTION
Adds Fence v0.8.7 as the first step of each Ubuntu matrix leg and pins those legs to Ubuntu 24.04. Authenticated audit review found no required custom destinations, so the Ubuntu legs now enforce with Fence’s default GitHub compatibility profile while macOS remains unchanged. The checksum-verified Linux Hugo package is extracted into the runner temp directory instead of requiring privileged installation.
