### PR TITLE
Restore ubuntu-latest runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
     name: build
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - if: matrix.os == 'ubuntu-24.04'
+      - if: matrix.os == 'ubuntu-latest'
         uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
 
       - name: checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,11 +16,11 @@ jobs:
     name: lint
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - if: matrix.os == 'ubuntu-24.04'
+      - if: matrix.os == 'ubuntu-latest'
         uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
 
       - name: checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,11 @@ jobs:
     name: test
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - if: matrix.os == 'ubuntu-24.04'
+      - if: matrix.os == 'ubuntu-latest'
         uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
 
       - name: checkout


### PR DESCRIPTION
Restores the Fence-covered Linux jobs from the explicit `ubuntu-24.04` label to `ubuntu-latest`. Fence pins, modes, allowlists, permissions, and job structure remain unchanged; matching workflow assertions are updated where present.